### PR TITLE
Add support to run rainbow_environment in docker

### DIFF
--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,10 +1,19 @@
-FROM node:14.2
+FROM golang:1.14.2-buster as build
 
+COPY ./vendor /vendor
+WORKDIR /vendor/ethashproof
+RUN ./build.sh
+
+FROM node:14.2.0-buster
+
+WORKDIR /app
+COPY --from=build /vendor/ethashproof/cmd/relayer/relayer ./vendor/ethashproof/cmd/relayer/relayer
 COPY ./package.json ./package.json
 COPY ./yarn.lock ./yarn.lock
 
 RUN yarn
 
-COPY . .
+COPY ./lib ./lib
+COPY ./index.js ./index.js
 
 ENTRYPOINT ["node", "index.js"]

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:14.2
+
+COPY ./package.json ./package.json
+COPY ./yarn.lock ./yarn.lock
+
+RUN yarn
+
+COPY . .
+
+ENTRYPOINT ["node", "index.js"]

--- a/rainbowup/main.py
+++ b/rainbowup/main.py
@@ -46,6 +46,8 @@ Run rainbowup <command> --help to see help for specific command.
                             default='local')
         parser.add_argument('--near_master_key_path', help='If specified, will use this key and the corresponding '
                                                       'account id to create accounts needed for the bridge.')
+        parser.add_argument('--rainbow_environment_image', help='If specified, will use this docker image to start EthRelayer'
+                                                                ' or NearRelayer instead of native nodejs')
         self.args = parser.parse_args()
         self.args.home = os.path.abspath(self.args.home)
         os.makedirs(self.args.home, exist_ok=True)

--- a/rainbowup/rainbowuplib/ethrelay_service.py
+++ b/rainbowup/rainbowuplib/ethrelay_service.py
@@ -41,5 +41,14 @@ class EthRelayService:
             VALIDATE_ETHASH=self.validate_ethash
         )
         print(env)
-        env = {**os.environ, **env}
-        subprocess.Popen(['node', 'index.js', 'start_ethrelay'], env=env, cwd=os.path.join(self.args.source, 'environment'), shell=False)
+        if self.args.rainbow_environment_image:
+            env_list = sum(list(map(lambda k: ['-e', k + '=' + env[k]], env)), [])
+            client_contract_path = os.path.abspath(env["ETH_CLIENT_CONTRACT_PATH"])
+            prover_contract_path = os.path.abspath(env["ETH_PROVER_CONTRACT_PATH"])
+            subprocess.Popen(['docker', 'run', '--network', 'host',
+                            '-v', f'{client_contract_path}:{client_contract_path}',
+                            '-v', f'{prover_contract_path}:{prover_contract_path}',
+                            *env_list, self.args.rainbow_environment_image, 'start_ethrelay'])
+        else:
+            env = {**os.environ, **env}
+            subprocess.Popen(['node', 'index.js', 'start_ethrelay'], env=env, cwd=os.path.join(self.args.source, 'environment'), shell=False)


### PR DESCRIPTION
This address #39 . To run it first go to enviroment/, build a docker image:
```
# first ensure eth relay is cloned in vendor:
git submodule update --init --recursive
docker build . -t rainbow_environment
```
(optionaly image can be tagged and pushed to remote)
Then in rainbowup/ run:
```
python3 main.py run --rainbow_environment_image rainbow_environment
```
It should works exactly same as native nodejs rainbow_environment