### PR TITLE
Parameter to run e2e test in nearcore ci

### DIFF
--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -9,7 +9,11 @@ ROOT_DIR=$CI_DIR/..
 
 cd $ROOT_DIR/environment
 yarn
-node index.js prepare
+if test -n "$LOCAL_CORE_SRC"; then
+  node index.js prepare --core-src $LOCAL_CORE_SRC
+else
+  node index.js prepare
+fi
 node index.js start near-node
 node index.js start ganache
 # Wait for the local node to start

--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -9,8 +9,8 @@ ROOT_DIR=$CI_DIR/..
 
 cd $ROOT_DIR/environment
 yarn
-if test -n "$LOCAL_CORE_SRC"; then
-  node index.js prepare --core-src $LOCAL_CORE_SRC
+if [ -n "${LOCAL_CORE_SRC+x}" ]; then
+  node index.js prepare --core-src "$LOCAL_CORE_SRC"
 else
   node index.js prepare
 fi

--- a/environment/commands/clean.js
+++ b/environment/commands/clean.js
@@ -7,25 +7,31 @@ const path = require('path');
 class CleanCommand {
     static execute() {
         console.log('Stopping all the running processes...');
-        ProcessManager.killDaemon((err) => {
+        ProcessManager.connect((err) => {
             if (err) {
-                console.log(`Error stopping pm2 processes. ${err}`);
-                process.exit(1);
+                // Never happened, but just log in case
+                console.log('Failed to launch pm2 daemon');
             }
-            ProcessManager.disconnect();
-            if (existsSync(path.join(homedir(), '.rainbow', 'nearup', 'main.py'))) {
-                try {
-                    console.log('Stopping nearup');
-                    execSync('python3 ~/.rainbow/nearup/main.py stop');
-                } catch (err) {
-                    console.log(`Error stopping nearup ${err}`);
+            ProcessManager.killDaemon((err) => {
+                if (err) {
+                    console.log(`Error stopping pm2 processes. ${err}`);
+                    process.exit(1);
                 }
-            }
-            console.log('Cleaning ~/.rainbow directory...');
-            execSync('rm -rf ~/.rainbow');
-            console.log('Cleaning done...');
-            process.exit(0);
-        });
+                ProcessManager.disconnect();
+                if (existsSync(path.join(homedir(), '.rainbow', 'nearup', 'main.py'))) {
+                    try {
+                        console.log('Stopping nearup');
+                        execSync('python3 ~/.rainbow/nearup/main.py stop');
+                    } catch (err) {
+                        console.log(`Error stopping nearup ${err}`);
+                    }
+                }
+                console.log('Cleaning ~/.rainbow directory...');
+                execSync('rm -rf ~/.rainbow');
+                console.log('Cleaning done...');
+                process.exit(0);
+            });
+        })
     }
 }
 

--- a/environment/commands/clean.js
+++ b/environment/commands/clean.js
@@ -26,8 +26,8 @@ class CleanCommand {
                         console.log(`Error stopping nearup ${err}`);
                     }
                 }
-                console.log('Cleaning ~/.rainbow directory...');
-                execSync('rm -rf ~/.rainbow');
+                console.log('Cleaning ~/.rainbow and ~/.near/localnet directory...');
+                execSync('rm -rf ~/.rainbow ~/.near/localnet');
                 console.log('Cleaning done...');
                 process.exit(0);
             });

--- a/environment/commands/prepare.js
+++ b/environment/commands/prepare.js
@@ -15,9 +15,9 @@ class PrepareCommand {
         for (const e in process.env) {
             env[e] = process.env[e];
         }
-        env.LOCAL_BRIDGE_SRC = path.resolve(RainbowConfig.getParam('bridge-src'));
-        env.LOCAL_CORE_SRC = path.resolve(RainbowConfig.getParam('core-src'));
-        env.LOCAL_NEARUP_SRC = path.resolve(RainbowConfig.getParam('nearup-src'));
+        env.LOCAL_BRIDGE_SRC = RainbowConfig.getParam('bridge-src') && path.resolve(RainbowConfig.getParam('bridge-src'));
+        env.LOCAL_CORE_SRC = RainbowConfig.getParam('core-src') && path.resolve(RainbowConfig.getParam('bridge-src'));
+        env.LOCAL_NEARUP_SRC = RainbowConfig.getParam('nearup-src') && path.resolve(RainbowConfig.getParam('bridge-src'));
 
         // @ts-ignore
         var prepareScript = exec(shell, { env: env });

--- a/environment/commands/prepare.js
+++ b/environment/commands/prepare.js
@@ -15,9 +15,9 @@ class PrepareCommand {
         for (const e in process.env) {
             env[e] = process.env[e];
         }
-        env.LOCAL_BRIDGE_SRC = RainbowConfig.getParam('bridge-src');
-        env.LOCAL_CORE_SRC = RainbowConfig.getParam('core-src');
-        env.LOCAL_NEARUP_SRC = RainbowConfig.getParam('nearup-src');
+        env.LOCAL_BRIDGE_SRC = path.resolve(RainbowConfig.getParam('bridge-src'));
+        env.LOCAL_CORE_SRC = path.resolve(RainbowConfig.getParam('core-src'));
+        env.LOCAL_NEARUP_SRC = path.resolve(RainbowConfig.getParam('nearup-src'));
 
         // @ts-ignore
         var prepareScript = exec(shell, { env: env });

--- a/environment/commands/prepare.js
+++ b/environment/commands/prepare.js
@@ -16,8 +16,8 @@ class PrepareCommand {
             env[e] = process.env[e];
         }
         env.LOCAL_BRIDGE_SRC = RainbowConfig.getParam('bridge-src') && path.resolve(RainbowConfig.getParam('bridge-src'));
-        env.LOCAL_CORE_SRC = RainbowConfig.getParam('core-src') && path.resolve(RainbowConfig.getParam('bridge-src'));
-        env.LOCAL_NEARUP_SRC = RainbowConfig.getParam('nearup-src') && path.resolve(RainbowConfig.getParam('bridge-src'));
+        env.LOCAL_CORE_SRC = RainbowConfig.getParam('core-src') && path.resolve(RainbowConfig.getParam('core-src'));
+        env.LOCAL_NEARUP_SRC = RainbowConfig.getParam('nearup-src') && path.resolve(RainbowConfig.getParam('nearup-src'));
 
         // @ts-ignore
         var prepareScript = exec(shell, { env: env });

--- a/environment/scripts/prepare.sh
+++ b/environment/scripts/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-eval rainbow_DIR=~/.rainbow
+eval RAINBOW_DIR=~/.rainbow
 
 export LOCAL_BRIDGE_SRC
 export LOCAL_CORE_SRC
@@ -13,7 +13,7 @@ eval NEARUP_SRC=~/.rainbow/nearup
 eval NEARUP_LOGS=~/.nearup/localnet-logs
 
 
-mkdir -p $rainbow_DIR
+mkdir -p $RAINBOW_DIR
 
 if test -z "$LOCAL_CORE_SRC"
 then


### PR DESCRIPTION
In rainbow-bridge, e2e.sh should take arg so it use local nearcore. In nearcore ci, it will checkout latest bridge, and run e2e.sh with current commit nearcore