### PR TITLE
make a shortcut index.js in path call rbb

### DIFF
--- a/environment/index.js
+++ b/environment/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const path = require('path')
 const { program } = require('commander')
 

--- a/environment/package.json
+++ b/environment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rainbow-bridge-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CLI to set up the environment needed for the bridge to work.",
   "main": "index.js",
   "author": "Near Inc.",
@@ -53,5 +53,8 @@
     "tabWidth": 2,
     "semi": false,
     "singleQuote": true
+  },
+  "bin": {
+    "rbb": "./index.js"
   }
 }


### PR DESCRIPTION
It's currently not exported, and have to find full path of rainbow-bridge-cli/index.js, which is not convenient. Export it in path. So after `npm i -g rainbow-bridge-cli`, `rbb` works:
```
➜  environment git:(npm-cli-fix) npm i -g rainbow-bridge-cli
npm WARN deprecated typechain-target-truffle@1.0.2: For TypeChain 2.x use @typechain/truffle-v4 or v5
npm WARN deprecated truffle-config@1.1.16: WARNING: This package has been renamed to @truffle/config.
npm WARN deprecated typechain-target-web3-v1@1.0.4: For TypeChain 2.x use @typechain/web3-v1
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated mkdirp-promise@5.0.1: This package is broken and no longer maintained. 'mkdirp' itself supports promises now, please switch to that.
npm WARN deprecated truffle-provider@0.1.16: WARNING: This package has been renamed to @truffle/provider.
npm WARN deprecated truffle-error@0.0.5: WARNING: This package has been renamed to @truffle/error.
npm WARN deprecated truffle-interface-adapter@0.2.5: WARNING: This package has been renamed to @truffle/interface-adapter.
npm WARN deprecated @web3-js/websocket@1.0.30: The branch for this fork was merged upstream, please update your package to websocket@1.0.31
npm WARN deprecated @web3-js/scrypt-shim@0.1.0: This package is deprecated, for a pure JS implementation please use scrypt-js
npm WARN deprecated multicodec@0.5.7: stable api reached
/Users/bo/.nvm/versions/node/v12.18.1/bin/rbb -> /Users/bo/.nvm/versions/node/v12.18.1/lib/node_modules/rainbow-bridge-cli/index.js

> websocket@1.0.31 install /Users/bo/.nvm/versions/node/v12.18.1/lib/node_modules/rainbow-bridge-cli/node_modules/eth-object/node_modules/websocket
> (node-gyp rebuild 2> builderror.log) || (exit 0)

  CXX(target) Release/obj.target/bufferutil/src/bufferutil.o
  SOLINK_MODULE(target) Release/bufferutil.node
  CXX(target) Release/obj.target/validation/src/validation.o
  SOLINK_MODULE(target) Release/validation.node

> web3@1.2.11 postinstall /Users/bo/.nvm/versions/node/v12.18.1/lib/node_modules/rainbow-bridge-cli/node_modules/eth-object/node_modules/web3
> node angular-patch.js

+ rainbow-bridge-cli@1.0.2
added 68 packages from 122 contributors and updated 3 packages in 25.407s
➜  environment git:(npm-cli-fix) rbb                              
Usage: rbb [options] [command]

Options:
  -V, --version                           output the version number
  -h, --help                              display help for command

Commands:
  clean
  prepare [options]
  status
  start
  stop
  init-near-contracts [options]           Deploys and initializes Near Client and Near Prover
                                          contracts to NEAR blockchain.
  init-eth-ed25519 [options]              Deploys and initializes ED25519 Solidity contract. It
                                          replaces missing precompile.
  init-eth-client [options]               Deploys and initializes EthClient.
  init-eth-prover [options]               Deploys and initializes EthProver.
  init-near-fun-token [options]           Deploys and initializes mintable fungible token to
                                          NEAR blockchain. Requires locker on Ethereum side.
  init-eth-locker [options]               Deploys and initializes locker contract on Ethereum
                                          blockchain. Requires mintable fungible token on Near
                                          side.
  init-eth-erc20 [options]                Deploys and initializes ERC20 contract on Ethereum
                                          blockchain.
  transfer-eth-erc20-to-near [options]
  transfer-eth-erc20-from-near [options]
  DANGER                                  Dangerous commands that should only be used for
                                          testing purpose.
  eth-dump [options] <kind_of_data>
  near-dump [options] <kind_of_data>
  help [command]                          display help for command
➜  environment git:(npm-cli-fix) rbb clean
Stopping all the running processes...
Stopping nearup
Cleaning ~/.rainbow and ~/.near/localnet directory...
Cleaning done...
```