### PR TITLE
fix near-watchdog not start on ci

### DIFF
--- a/environment/scripts/prepare.sh
+++ b/environment/scripts/prepare.sh
@@ -12,8 +12,19 @@ eval CORE_SRC=~/.rainbow/core
 eval NEARUP_SRC=~/.rainbow/nearup
 eval NEARUP_LOGS=~/.nearup/localnet-logs
 
-
 mkdir -p $RAINBOW_DIR
+mkdir -p $RAINBOW_DIR/logs/ganache
+mkdir -p $RAINBOW_DIR/logs/near-relay
+mkdir -p $RAINBOW_DIR/logs/eth-relay
+mkdir -p $RAINBOW_DIR/logs/near-watchdog
+touch $RAINBOW_DIR/logs/ganache/out.log
+touch $RAINBOW_DIR/logs/ganache/err.log
+touch $RAINBOW_DIR/logs/near-relay/out.log
+touch $RAINBOW_DIR/logs/near-relay/err.log
+touch $RAINBOW_DIR/logs/eth-relay/out.log
+touch $RAINBOW_DIR/logs/eth-relay/err.log
+touch $RAINBOW_DIR/logs/near-watchdog/out.log
+touch $RAINBOW_DIR/logs/near-watchdog/err.log
 
 if test -z "$LOCAL_CORE_SRC"
 then


### PR DESCRIPTION
Fix #271 
This happens about 20% of the time and only on ci. Finally figure out cause from `~/.pm2/pm2.log`:
```
2020-08-18T00:35:04: PM2 log: App [ganache:0] starting in -fork mode-
2020-08-18T00:35:04: PM2 log: App [ganache:0] online
2020-08-18T00:36:35: PM2 log: App [near-relay:1] starting in -fork mode-
2020-08-18T00:36:38: PM2 log: App [near-relay:1] online
2020-08-18T00:36:44: PM2 log: App [eth-relay:2] starting in -fork mode-
2020-08-18T00:36:47: PM2 log: App [eth-relay:2] online
2020-08-18T00:36:54: PM2 log: App [near-watchdog:3] starting in -fork mode-
2020-08-18T00:36:54: PM2 error: Trace: [Error: ENOENT: no such file or directory, open '/var/lib/buildkite-agent/.rainbow/logs/near-watchdog/out.log'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/var/lib/buildkite-agent/.rainbow/logs/near-watchdog/out.log'
}
    at Object.God.logAndGenerateError (/var/lib/buildkite-agent/rainbow-bridge/environment/node_modules/pm2/lib/God/Methods.js:34:15)
    at /var/lib/buildkite-agent/rainbow-bridge/environment/node_modules/pm2/lib/God/ForkMode.js:92:13
    at wrapper (/var/lib/buildkite-agent/rainbow-bridge/environment/node_modules/pm2/node_modules/async/internal/once.js:12:16)
    at WriteStream.next (/var/lib/buildkite-agent/rainbow-bridge/environment/node_modules/pm2/node_modules/async/waterfall.js:96:20)
    at WriteStream.<anonymous> (/var/lib/buildkite-agent/rainbow-bridge/environment/node_modules/pm2/node_modules/async/internal/onlyOnce.js:12:16)
    at Object.onceWrapper (events.js:428:26)
    at WriteStream.emit (events.js:321:20)
    at WriteStream.EventEmitter.emit (domain.js:485:12)
    at internal/fs/streams.js:398:14
    at FSReqCallback.oncomplete (fs.js:158:23)
```
So pm2 didn't wait until the log file or log dir is successfully created before spawn process. Create them in advance should fix it (due to it was only fail 20% of time, need to confirm by rerun a few times)