### PR TITLE
patch version so contract repo changes trigger ci here

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,7 @@ steps:
     command: |
       source ci/e2e_ci_prepare_env.sh
       source ci/e2e_ci_prepare_log.sh
+      node ci/patch_contract_version.js
       ci/e2e.sh
 
     artifact_paths:
@@ -16,6 +17,7 @@ steps:
     command: |
       source ci/e2e_ci_prepare_env.sh
       source ci/e2e_ci_prepare_log.sh
+      node ci/patch_contract_version.js
       ci/test_challenge.sh
 
     artifact_paths:
@@ -29,6 +31,7 @@ steps:
     command: |
       source ci/e2e_ci_prepare_env.sh
       source ci/e2e_ci_prepare_log.sh
+      node ci/patch_contract_version.js
       ci/test_ethrelay_catchup.sh
 
     artifact_paths:
@@ -42,6 +45,7 @@ steps:
     command: |
       source ci/e2e_ci_prepare_env.sh
       source ci/e2e_ci_prepare_log.sh
+      node ci/patch_contract_version.js
       ci/test_npm_package.sh
 
     artifact_paths:

--- a/ci/patch_contract_version.js
+++ b/ci/patch_contract_version.js
@@ -6,18 +6,22 @@ const fs = require('fs')
 async function main() {
   let packageJson = require(path.join(__dirname, '../environment/package.json'))
   if (process.env.PATCH_RAINBOW_BRIDGE_SOL) {
-    packageJson[
+    packageJson.dependencies[
       'rainbow-bridge-sol'
     ] = `near/rainbow-bridge-sol#${process.env.PATCH_RAINBOW_BRIDGE_SOL}`
   }
   if (process.env.PATCH_RAINBOW_BRIDGE_RS) {
-    packageJson[
+    packageJson.dependencies[
       'rainbow-bridge-rs'
     ] = `near/rainbow-bridge-rs#${process.env.PATCH_RAINBOW_BRIDGE_RS}`
   }
   console.log('Contract versions:')
-  console.log(`rainbow-bridge-sol: ${packageJson['rainbow-bridge-sol']}`)
-  console.log(`rainbow-bridge-rs: ${packageJson['rainbow-bridge-rs']}`)
+  console.log(
+    `rainbow-bridge-sol: ${packageJson.dependencies['rainbow-bridge-sol']}`
+  )
+  console.log(
+    `rainbow-bridge-rs: ${packageJson.dependencies['rainbow-bridge-rs']}`
+  )
   if (
     !process.env.PATCH_RAINBOW_BRIDGE_SOL &&
     !process.env.PATCH_RAINBOW_BRIDGE_RS

--- a/ci/patch_contract_version.js
+++ b/ci/patch_contract_version.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+const path = require('path')
+const fs = require('fs')
+
+async function main() {
+  let packageJson = require(path.join(__dirname, '../environment/package.json'))
+  if (process.env.PATCH_RAINBOW_BRIDGE_SOL) {
+    packageJson[
+      'rainbow-bridge-sol'
+    ] = `near/rainbow-bridge-sol#${process.env.PATCH_RAINBOW_BRIDGE_SOL}`
+  }
+  if (process.env.PATCH_RAINBOW_BRIDGE_RS) {
+    packageJson[
+      'rainbow-bridge-rs'
+    ] = `near/rainbow-bridge-rs#${process.env.PATCH_RAINBOW_BRIDGE_RS}`
+  }
+  console.log('Contract versions:')
+  console.log(`rainbow-bridge-sol: ${packageJson['rainbow-bridge-sol']}`)
+  console.log(`rainbow-bridge-rs: ${packageJson['rainbow-bridge-rs']}`)
+  if (
+    !process.env.PATCH_RAINBOW_BRIDGE_SOL &&
+    !process.env.PATCH_RAINBOW_BRIDGE_RS
+  ) {
+    process.exit()
+  }
+
+  fs.writeFileSync(
+    path.join(__dirname, '../environment/package.json'),
+    JSON.stringify(packageJson)
+  )
+}
+
+main()


### PR DESCRIPTION
As point out by @Kouprin , change in rainbow-bridge-sol and rainbow-bridge-rs should trigger ci here. The other direction is not needed because rainbow-bridge-cli use pinned version of some rainbow-bridge-sol & rainbow-bridge-rs which're already tested against cli before before published.

So the test trigger happens like this:
1. post a pr in rainbow-bridge-rs or rainbow-bridge-sol
2. contract unit tests run and pass
3. trigger integration test in rainbow-bridge-cli repo, with rainbow-bridge-sol/rs version set as commit hash of 3.
4. integration test pass and run

After 4, we can confidently merge contract repo PR, do a npm publish in contract repo, and depend on new version of contract in this cli repo.