### PR TITLE
Adjustment to e2e tests so solidity contract works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ node index.js transfer-eth-erc20-from-near --amount 1 --near-sender-account rain
 
 You should observe the change of the ERC20 balance as reported by the CLI.
 
-## Contract Development Workflow
+## Contract and rainbow-bridge-lib Development Workflow
 
 Above steps are ways to run a local bridge and development workflows you need if make any changes to rainbow-bridge-cli. If you want to update any of solidity or rust contracts, they're not in this repo now and workflow is as following.
 
@@ -242,7 +242,13 @@ node start ganache
 - Follow instructions above to init eth contracts and near contracts, start services and start testing with bridge
 - For changes to Solidity contract, Rust contract, and rainbow-bridge-lib, please submit PRs to: https://github.com/near/rainbow-bridge-sol , https://github.com/near/rainbow-bridge-rs , and https://github.com/near/rainbow-bridge-lib respectively.
 - After PR merged in contract repos and rainbow-bridge-lib repo, we will periodically publish them as new version of npm packages. And rainbow-bridge-cli will adopt new version of them.
-
+- If there is a change need to change one or more of rainbow-bridge-sol/rs/lib and also rainbow-bridge-cli to pass CI
+  - To test it locally, you can modify package.json to use local path of rainbow-bridge-sol/rs/lib, `yarn` and run e2e tests.
+  - Create one PR in rainbow-bridge-sol/rs/lib and one PR in rainbow-bridge-lib
+  - In rainbow-bridge-sol/rs/lib PR remember to increase version in package.json
+  - rainbow-bridge-sol/rs/lib PR has to pass unit tests. Tests in rainbow-bridge-cli is expected to fail
+  - Merge rainbow-bridge-sol/rs/lib PR, npm publish, and use new version of that in rainbow-bridge-cli's package.json
+  - PR in rainbow-bridge-cli CI must pass to prove the bridge still works after change in both repos 
 
 <!---
 The following is outdated.

--- a/README.md
+++ b/README.md
@@ -242,9 +242,9 @@ node start ganache
 - Follow instructions above to init eth contracts and near contracts, start services and start testing with bridge
 - For changes to Solidity contract, Rust contract, and rainbow-bridge-lib, please submit PRs to: https://github.com/near/rainbow-bridge-sol , https://github.com/near/rainbow-bridge-rs , and https://github.com/near/rainbow-bridge-lib respectively.
 - After PR merged in contract repos and rainbow-bridge-lib repo, we will periodically publish them as new version of npm packages. And rainbow-bridge-cli will adopt new version of them.
-- If there is a change need to change one or more of rainbow-bridge-sol/rs/lib and also rainbow-bridge-cli to pass CI
+- If there is a need to change rainbow-bridge-sol/rs/lib and also rainbow-bridge-cli to pass CI
   - To test it locally, you can modify package.json to use local path of rainbow-bridge-sol/rs/lib, `yarn` and run e2e tests.
-  - Create one PR in rainbow-bridge-sol/rs/lib and one PR in rainbow-bridge-lib
+  - Create one PR in rainbow-bridge-sol/rs/lib and one PR in rainbow-bridge-cli
   - In rainbow-bridge-sol/rs/lib PR remember to increase version in package.json
   - rainbow-bridge-sol/rs/lib PR has to pass unit tests. Tests in rainbow-bridge-cli is expected to fail
   - Merge rainbow-bridge-sol/rs/lib PR, npm publish, and use new version of that in rainbow-bridge-cli's package.json

--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -38,7 +38,7 @@ node index.js init-near-fun-token
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201
+node index.js start near2eth-relay
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay

--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -51,6 +51,7 @@ node index.js transfer-eth-erc20-to-near --amount 1000 \
 grep "Balance of rainbow_bridge_eth_on_near_prover after the transfer is 1000" /tmp/eth2neartransfer.out
 node index.js transfer-eth-erc20-from-near --amount 1 --near-sender-account rainbow_bridge_eth_on_near_prover \
 --near-sender-sk ed25519:3D4YudUQRE39Lc4JHghuB5WM8kbgDDa34mnrEP5DdTApVH81af7e2dWgNPEaiQfdJnZq1CNPp5im4Rg5b733oiMP \
+--eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201 \
 --eth-receiver-address 0xEC8bE1A5630364292E56D01129E8ee8A9578d7D8 \
 2>&1 | tee -a /tmp/near2ethtransfer.out
 grep "after the transfer: 1" /tmp/near2ethtransfer.out

--- a/ci/test_challenge.sh
+++ b/ci/test_challenge.sh
@@ -38,7 +38,7 @@ node index.js init-near-fun-token
 
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201
+node index.js start near2eth-relay
 sleep 5
 yarn run pm2 list
 node index.js start eth2near-relay

--- a/ci/test_challenge.sh
+++ b/ci/test_challenge.sh
@@ -62,5 +62,6 @@ grep "Balance of rainbow_bridge_eth_on_near_prover after the transfer is 1000" /
 node index.js transfer-eth-erc20-from-near --amount 1 --near-sender-account rainbow_bridge_eth_on_near_prover \
 --near-sender-sk ed25519:3D4YudUQRE39Lc4JHghuB5WM8kbgDDa34mnrEP5DdTApVH81af7e2dWgNPEaiQfdJnZq1CNPp5im4Rg5b733oiMP \
 --eth-receiver-address 0xEC8bE1A5630364292E56D01129E8ee8A9578d7D8 \
+--eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201 \
 2>&1 | tee -a /tmp/near2ethtransfer.out
 grep "after the transfer: 1" /tmp/near2ethtransfer.out

--- a/ci/test_ethrelay_catchup.sh
+++ b/ci/test_ethrelay_catchup.sh
@@ -38,7 +38,7 @@ node index.js init-near-fun-token
 yarn run pm2 ping
 sleep 5
 yarn run pm2 list
-node index.js start near2eth-relay --eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201
+node index.js start near2eth-relay
 sleep 5
 yarn run pm2 list
 sleep 100

--- a/ci/test_ethrelay_catchup.sh
+++ b/ci/test_ethrelay_catchup.sh
@@ -53,5 +53,6 @@ grep "Balance of rainbow_bridge_eth_on_near_prover after the transfer is 1000" /
 node index.js transfer-eth-erc20-from-near --amount 1 --near-sender-account rainbow_bridge_eth_on_near_prover \
 --near-sender-sk ed25519:3D4YudUQRE39Lc4JHghuB5WM8kbgDDa34mnrEP5DdTApVH81af7e2dWgNPEaiQfdJnZq1CNPp5im4Rg5b733oiMP \
 --eth-receiver-address 0xEC8bE1A5630364292E56D01129E8ee8A9578d7D8 \
+--eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201 \
 2>&1 | tee -a /tmp/near2ethtransfer.out
 grep "after the transfer: 1" /tmp/near2ethtransfer.out

--- a/ci/test_npm_package.sh
+++ b/ci/test_npm_package.sh
@@ -65,5 +65,6 @@ grep "Balance of rainbow_bridge_eth_on_near_prover after the transfer is 1000" /
 rainbow transfer-eth-erc20-from-near --amount 1 --near-sender-account rainbow_bridge_eth_on_near_prover \
 --near-sender-sk ed25519:3D4YudUQRE39Lc4JHghuB5WM8kbgDDa34mnrEP5DdTApVH81af7e2dWgNPEaiQfdJnZq1CNPp5im4Rg5b733oiMP \
 --eth-receiver-address 0xEC8bE1A5630364292E56D01129E8ee8A9578d7D8 \
+--eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201 \
 2>&1 | tee -a /tmp/near2ethtransfer.out
 grep "after the transfer: 1" /tmp/near2ethtransfer.out

--- a/ci/test_npm_package.sh
+++ b/ci/test_npm_package.sh
@@ -51,7 +51,7 @@ cd ${ROOT_DIR}/testenv/
 yarn pm2 ping
 sleep 5
 yarn pm2 list
-rainbow start near2eth-relay --eth-master-sk 0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201
+rainbow start near2eth-relay
 sleep 5
 yarn pm2 list
 rainbow start eth2near-relay

--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,7 +1869,7 @@ eth-lib@^0.2.8:
     elliptic "^6.4.0"
     xhr-request-promise "^0.1.2"
 
-"eth-object@github:near/eth-object#54e03b8aac8208cf724e206d49ffb8bdd30451d7", eth-object@near/eth-object#54e03b8aac8208cf724e206d49ffb8bdd30451d7:
+eth-object@near/eth-object#54e03b8aac8208cf724e206d49ffb8bdd30451d7:
   version "1.0.3"
   resolved "https://codeload.github.com/near/eth-object/tar.gz/54e03b8aac8208cf724e206d49ffb8bdd30451d7"
   dependencies:
@@ -1877,7 +1877,7 @@ eth-lib@^0.2.8:
     ethereumjs-util "^7.0.3"
     web3 "^1.2.9"
 
-"eth-util-lite@github:near/eth-util-lite#master", eth-util-lite@near/eth-util-lite#master:
+eth-util-lite@near/eth-util-lite#master:
   version "1.0.1"
   resolved "https://codeload.github.com/near/eth-util-lite/tar.gz/ae0210cbe127b4d43ba01fd7cd4898d1a3f6c96a"
   dependencies:


### PR DESCRIPTION
See manual ci run of this PR: https://buildkite.com/nearprotocol/rainbow-bridge/builds/725
it's "after merge https://github.com/near/rainbow-bridge-sol/pull/11" and run e2e tests.

Don't merge before https://github.com/near/rainbow-bridge-sol/pull/11 merge and new rainbow-bridge-sol is published 