### PR TITLE
refactor: Decouple RainbowConfig

### DIFF
--- a/cli/commands/danger-deploy-myerc20.js
+++ b/cli/commands/danger-deploy-myerc20.js
@@ -3,7 +3,12 @@ const { BN } = require('ethereumjs-util')
 const fs = require('fs')
 
 class DangerDeployMyERC20 {
-  static async execute ({ ethNodeUrl, ethMasterSk, ethErc20AbiPath, ethGasMultiplier }) {
+  static async execute ({
+    ethNodeUrl,
+    ethMasterSk,
+    ethErc20AbiPath,
+    ethGasMultiplier
+  }) {
     const web3 = new Web3(ethNodeUrl)
     let ethMasterAccount = web3.eth.accounts.privateKeyToAccount(
       normalizeEthKey(ethMasterSk)

--- a/cli/commands/danger-deploy-myerc20.js
+++ b/cli/commands/danger-deploy-myerc20.js
@@ -1,23 +1,22 @@
-const { Web3, RainbowConfig, normalizeEthKey } = require('rainbow-bridge-utils')
+const { Web3, normalizeEthKey } = require('rainbow-bridge-utils')
 const { BN } = require('ethereumjs-util')
 const fs = require('fs')
 
 class DangerDeployMyERC20 {
-  static async execute () {
-    const web3 = new Web3(RainbowConfig.getParam('eth-node-url'))
+  static async execute ({ ethNodeUrl, ethMasterSk, ethErc20AbiPath, ethGasMultiplier }) {
+    const web3 = new Web3(ethNodeUrl)
     let ethMasterAccount = web3.eth.accounts.privateKeyToAccount(
-      normalizeEthKey(RainbowConfig.getParam('eth-master-sk'))
+      normalizeEthKey(ethMasterSk)
     )
     web3.eth.accounts.wallet.add(ethMasterAccount)
     web3.eth.defaultAccount = ethMasterAccount.address
     ethMasterAccount = ethMasterAccount.address
 
     // use default ERC20 ABI
-    const abiPath = RainbowConfig.getParam('eth-erc20-abi-path')
     const binPath = '../testing/ci/MyERC20.full.bin'
 
     const tokenContract = new web3.eth.Contract(
-      JSON.parse(fs.readFileSync(abiPath))
+      JSON.parse(fs.readFileSync(ethErc20AbiPath))
     )
     const txContract = await tokenContract
       .deploy({
@@ -28,7 +27,7 @@ class DangerDeployMyERC20 {
         from: ethMasterAccount,
         gas: 3000000,
         gasPrice: new BN(await web3.eth.getGasPrice()).mul(
-          new BN(RainbowConfig.getParam('eth-gas-multiplier'))
+          new BN(ethGasMultiplier)
         )
       })
 

--- a/cli/commands/danger-submit-invalid-near-block.js
+++ b/cli/commands/danger-submit-invalid-near-block.js
@@ -1,10 +1,34 @@
 const { Near2EthRelay } = require('rainbow-bridge-near2eth-block-relay')
 
 class DangerSubmitInvalidNearBlock {
-  static async execute () {
+  static async execute ({
+    nearNodeUrl,
+    nearNetworkId,
+    ethNodeUrl,
+    ethMasterSk,
+    ethClientAbiPath,
+    ethClientAddress,
+    ethGasMultiplier,
+    near2ethRelayMinDelay,
+    near2ethRelayMaxDelay,
+    near2ethRelayErrorDelay
+  }) {
     const relay = new Near2EthRelay()
-    await relay.initialize()
-    await relay.DANGERsubmitInvalidNearBlock()
+    await relay.initialize({
+      nearNodeUrl,
+      nearNetworkId,
+      ethNodeUrl,
+      ethMasterSk,
+      ethClientAbiPath,
+      ethClientAddress,
+      ethGasMultiplier
+    })
+    await relay.DANGERsubmitInvalidNearBlock({
+      near2ethRelayMinDelay,
+      near2ethRelayMaxDelay,
+      near2ethRelayErrorDelay,
+      ethGasMultiplier
+    })
   }
 }
 

--- a/cli/commands/near-dump.js
+++ b/cli/commands/near-dump.js
@@ -91,7 +91,7 @@ async function getNextLightClientBlock (nearNodeUrl, blockHash) {
 }
 
 class NearDump {
-  static async execute (kindOfData, { path, numBlocks }) {
+  static async execute (kindOfData, { path, numBlocks, nearNodeUrl }) {
     if (kindOfData !== 'headers' && kindOfData !== 'proofs') {
       console.log(
         'Usage: node index.js near-dump headers\n       node index.js near-dump proofs'
@@ -102,8 +102,6 @@ class NearDump {
     if (!numBlocks) {
       numBlocks = 100
     }
-    const nearNodeUrl = RainbowConfig.getParam('near-node-url')
-
     const latestBlock = await getLatestBlock(nearNodeUrl)
 
     if (kindOfData === 'headers') {

--- a/cli/commands/near-dump.js
+++ b/cli/commands/near-dump.js
@@ -1,6 +1,5 @@
 const fs = require('fs').promises
 const Path = require('path')
-const { RainbowConfig } = require('rainbow-bridge-utils')
 const fetch = require('node-fetch')
 
 async function getLatestBlock (nearNodeUrl) {

--- a/cli/commands/prepare.js
+++ b/cli/commands/prepare.js
@@ -1,9 +1,10 @@
 const { exec } = require('child_process')
 const path = require('path')
-const { RainbowConfig, getScript } = require('rainbow-bridge-utils')
+
+const { getScript } = require('rainbow-bridge-utils')
 
 class PrepareCommand {
-  static execute () {
+  static execute ({ coreSrc, nearupSrc }) {
     const scriptDir = getScript('prepare')
 
     const shell = ['bash', scriptDir].join(' ')
@@ -13,13 +14,9 @@ class PrepareCommand {
       env[e] = process.env[e]
     }
 
-    env.LOCAL_CORE_SRC =
-      RainbowConfig.getParam('core-src') &&
-      path.resolve(RainbowConfig.getParam('core-src'))
+    env.LOCAL_CORE_SRC = coreSrc && path.resolve(coreSrc)
 
-    env.LOCAL_NEARUP_SRC =
-      RainbowConfig.getParam('nearup-src') &&
-      path.resolve(RainbowConfig.getParam('nearup-src'))
+    env.LOCAL_NEARUP_SRC = nearupSrc && path.resolve(nearupSrc)
 
     // @ts-ignore
     const prepareScript = exec(shell, { env: env })

--- a/cli/commands/start/eth2near-relay.js
+++ b/cli/commands/start/eth2near-relay.js
@@ -31,7 +31,15 @@ class StartEth2NearRelayCommand {
           interpreter: 'node',
           error_file: '~/.rainbow/logs/eth2near-relay/err.log',
           out_file: '~/.rainbow/logs/eth2near-relay/out.log',
-          args: ['start', 'eth2near-relay', ...RainbowConfig.getArgsNoDaemon()],
+          args: [
+            'start', 'eth2near-relay',
+            '--near-network-id', nearNetworkId,
+            '--near-node-url', nearNodeUrl,
+            '--near-master-account', nearMasterAccount,
+            '--near-master-sk', nearMasterSk,
+            '--near-client-account', nearClientAccount,
+            '--eth-node-url', ethNodeUrl
+          ],
           wait_ready: true,
           kill_timeout: 60000,
           logDateFormat: 'YYYY-MM-DD HH:mm:ss.SSS'
@@ -60,7 +68,7 @@ class StartEth2NearRelayCommand {
       )
       await clientContract.accessKeyInit()
       console.log('Initializing eth2near-relay...')
-      relay.initialize(clientContract, ethNodeUrl)
+      relay.initialize(clientContract, { ethNodeUrl })
       console.log('Starting eth2near-relay...')
       await relay.run()
     }

--- a/cli/commands/start/eth2near-relay.js
+++ b/cli/commands/start/eth2near-relay.js
@@ -38,7 +38,8 @@ class StartEth2NearRelayCommand {
             '--near-master-account', nearMasterAccount,
             '--near-master-sk', nearMasterSk,
             '--near-client-account', nearClientAccount,
-            '--eth-node-url', ethNodeUrl
+            '--eth-node-url', ethNodeUrl,
+            '--daemon', 'false'
           ],
           wait_ready: true,
           kill_timeout: 60000,

--- a/cli/commands/start/ganache.js
+++ b/cli/commands/start/ganache.js
@@ -21,13 +21,11 @@ class StartGanacheNodeCommand {
         logDateFormat: 'YYYY-MM-DD HH:mm:ss.SSS'
       })
     })
-    RainbowConfig.setParam('eth-node-url', 'ws://localhost:9545')
-    RainbowConfig.setParam(
-      'eth-master-sk',
-      '0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501200'
-    )
-    RainbowConfig.setParam('near-client-validate-ethash', 'false')
-    RainbowConfig.saveConfig()
+    return {
+      ethNodeUrl: 'ws://localhost:9545',
+      ethMasterSk: '0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501200',
+      nearClientValidateEthash: 'false'
+    }
   }
 }
 

--- a/cli/commands/start/ganache.js
+++ b/cli/commands/start/ganache.js
@@ -1,6 +1,6 @@
 const ProcessManager = require('pm2')
 const { spawnProcess } = require('./helpers')
-const { RainbowConfig, getScript } = require('rainbow-bridge-utils')
+const { getScript } = require('rainbow-bridge-utils')
 
 class StartGanacheNodeCommand {
   static async execute () {

--- a/cli/commands/start/near.js
+++ b/cli/commands/start/near.js
@@ -17,14 +17,12 @@ class StartLocalNearNodeCommand {
         console.log('Local Node is already running. Skipping...')
       }
     })
-    RainbowConfig.setParam('near-node-url', 'http://localhost:3030')
-    RainbowConfig.setParam('near-network-id', 'local')
-    RainbowConfig.setParam('near-master-account', 'node0')
-    RainbowConfig.setParam(
-      'near-master-sk',
-      'ed25519:3D4YudUQRE39Lc4JHghuB5WM8kbgDDa34mnrEP5DdTApVH81af7e2dWgNPEaiQfdJnZq1CNPp5im4Rg5b733oiMP'
-    )
-    RainbowConfig.saveConfig()
+    return {
+      nearNodeUrl: 'http://localhost:3030',
+      nearNetworkId: 'local',
+      nearMasterAccount: 'node0',
+      nearMasterSk: 'ed25519:3D4YudUQRE39Lc4JHghuB5WM8kbgDDa34mnrEP5DdTApVH81af7e2dWgNPEaiQfdJnZq1CNPp5im4Rg5b733oiMP'
+    }
   }
 }
 

--- a/cli/commands/start/near.js
+++ b/cli/commands/start/near.js
@@ -1,8 +1,8 @@
 const util = require('util')
 const { execSync } = require('child_process')
 const request = require('request')
+
 const { getLocalNearNodeURL } = require('./helpers')
-const { RainbowConfig } = require('rainbow-bridge-utils')
 
 class StartLocalNearNodeCommand {
   static execute () {

--- a/cli/commands/start/near2eth-relay.js
+++ b/cli/commands/start/near2eth-relay.js
@@ -1,12 +1,11 @@
 const ProcessManager = require('pm2')
 const { spawnProcess } = require('./helpers')
 const { Near2EthRelay } = require('rainbow-bridge-near2eth-block-relay')
-const { RainbowConfig } = require('rainbow-bridge-utils')
 const path = require('path')
 
 class StartNear2EthRelayCommand {
-  static async execute () {
-    if (RainbowConfig.getParam('daemon') === 'true') {
+  static async execute ({ daemon }) {
+    if (daemon === 'true') {
       ProcessManager.connect((err) => {
         if (err) {
           console.log(

--- a/cli/commands/start/near2eth-relay.js
+++ b/cli/commands/start/near2eth-relay.js
@@ -42,7 +42,8 @@ class StartNear2EthRelayCommand {
             '--eth-gas-multiplier', ethGasMultiplier,
             '--near2eth-relay-min-delay', near2ethRelayMinDelay,
             '--near2eth-relay-max-delay', near2ethRelayMaxDelay,
-            '--near2eth-relay-error-delay', near2ethRelayErrorDelay
+            '--near2eth-relay-error-delay', near2ethRelayErrorDelay,
+            '--daemon', 'false'
           ],
           wait_ready: true,
           kill_timeout: 60000,

--- a/cli/commands/start/near2eth-relay.js
+++ b/cli/commands/start/near2eth-relay.js
@@ -4,7 +4,19 @@ const { Near2EthRelay } = require('rainbow-bridge-near2eth-block-relay')
 const path = require('path')
 
 class StartNear2EthRelayCommand {
-  static async execute ({ daemon }) {
+  static async execute ({
+    daemon,
+    nearNodeUrl,
+    nearNetworkId,
+    ethNodeUrl,
+    ethMasterSk,
+    ethClientAbiPath,
+    ethClientAddress,
+    ethGasMultiplier,
+    near2ethRelayMinDelay,
+    near2ethRelayMaxDelay,
+    near2ethRelayErrorDelay
+  }) {
     if (daemon === 'true') {
       ProcessManager.connect((err) => {
         if (err) {
@@ -19,7 +31,19 @@ class StartNear2EthRelayCommand {
           interpreter: 'node',
           error_file: '~/.rainbow/logs/near2eth-relay/err.log',
           out_file: '~/.rainbow/logs/near2eth-relay/out.log',
-          args: ['start', 'near2eth-relay', ...RainbowConfig.getArgsNoDaemon()],
+          args: [
+            'start', 'near2eth-relay',
+            '--near-node-url', nearNodeUrl,
+            '--near-network-id', nearNetworkId,
+            '--eth-node-url', ethNodeUrl,
+            '--eth-master-sk', ethMasterSk,
+            '--eth-client-abi-path', ethClientAbiPath,
+            '--eth-client-address', ethClientAddress,
+            '--eth-gas-multiplier', ethGasMultiplier,
+            '--near2eth-relay-min-delay', near2ethRelayMinDelay,
+            '--near2eth-relay-max-delay', near2ethRelayMaxDelay,
+            '--near2eth-relay-error-delay', near2ethRelayErrorDelay
+          ],
           wait_ready: true,
           kill_timeout: 60000,
           logDateFormat: 'YYYY-MM-DD HH:mm:ss.SSS'
@@ -27,8 +51,21 @@ class StartNear2EthRelayCommand {
       })
     } else {
       const relay = new Near2EthRelay()
-      await relay.initialize()
-      await relay.run()
+      await relay.initialize({
+        nearNodeUrl,
+        nearNetworkId,
+        ethNodeUrl,
+        ethMasterSk,
+        ethClientAbiPath,
+        ethClientAddress,
+        ethGasMultiplier
+      })
+      await relay.run({
+        near2ethRelayMinDelay,
+        near2ethRelayMaxDelay,
+        near2ethRelayErrorDelay,
+        ethGasMultiplier
+      })
     }
   }
 }

--- a/cli/commands/start/watchdog.js
+++ b/cli/commands/start/watchdog.js
@@ -4,7 +4,15 @@ const { Watchdog } = require('rainbow-bridge-watchdog')
 const path = require('path')
 
 class StartWatchdogCommand {
-  static async execute ({ daemon }) {
+  static async execute ({
+    daemon,
+    ethNodeUrl,
+    ethMasterSk,
+    ethClientAbiPath,
+    ethClientAddress,
+    watchdogDelay,
+    watchdogErrorDelay
+  }) {
     if (daemon === 'true') {
       ProcessManager.connect((err) => {
         if (err) {
@@ -22,15 +30,30 @@ class StartWatchdogCommand {
           args: [
             'start',
             'bridge-watchdog',
-            ...RainbowConfig.getArgsNoDaemon()
+            '--eth-node-url', ethNodeUrl,
+            '--eth-master-sk', ethMasterSk,
+            '--eth-client-abi-path', ethClientAbiPath,
+            '--eth-client-address', ethClientAddress,
+            '--watchdog-delay', watchdogDelay,
+            '--watchdog-error-delay', watchdogErrorDelay
           ],
           logDateFormat: 'YYYY-MM-DD HH:mm:ss.SSS'
         })
       })
     } else {
       const watchdog = new Watchdog()
-      await watchdog.initialize()
-      await watchdog.run()
+      await watchdog.initialize({
+        ethNodeUrl,
+        ethMasterSk,
+        ethClientAbiPath,
+        ethClientAddress
+      })
+      await watchdog.run({
+        ethMasterSk,
+        ethClientAddress,
+        watchdogDelay,
+        watchdogErrorDelay
+      })
     }
   }
 }

--- a/cli/commands/start/watchdog.js
+++ b/cli/commands/start/watchdog.js
@@ -35,7 +35,8 @@ class StartWatchdogCommand {
             '--eth-client-abi-path', ethClientAbiPath,
             '--eth-client-address', ethClientAddress,
             '--watchdog-delay', watchdogDelay,
-            '--watchdog-error-delay', watchdogErrorDelay
+            '--watchdog-error-delay', watchdogErrorDelay,
+            '--daemon', 'false'
           ],
           logDateFormat: 'YYYY-MM-DD HH:mm:ss.SSS'
         })

--- a/cli/commands/start/watchdog.js
+++ b/cli/commands/start/watchdog.js
@@ -1,12 +1,11 @@
 const ProcessManager = require('pm2')
 const { spawnProcess } = require('./helpers')
 const { Watchdog } = require('rainbow-bridge-watchdog')
-const { RainbowConfig } = require('rainbow-bridge-utils')
 const path = require('path')
 
 class StartWatchdogCommand {
-  static async execute () {
-    if (RainbowConfig.getParam('daemon') === 'true') {
+  static async execute ({ daemon }) {
+    if (daemon === 'true') {
       ProcessManager.connect((err) => {
         if (err) {
           console.log(

--- a/cli/index.js
+++ b/cli/index.js
@@ -503,14 +503,14 @@ RainbowConfig.addOptions(
   program
     .command('deploy-token <token_name> <eth_token_address>')
     .description('Deploys and initializes token on NEAR.'),
-  (args) => {
-    const deployedTokenInfo = DeployToken.execute(args)
+  (tokenName, ethTokenAddress, args) => {
+    const deployedTokenInfo = DeployToken.execute({ tokenName, ethTokenAddress, ...args })
     if (!deployedTokenInfo) {
       return null
     }
     const {
       nearTokenAccount,
-      ethTokenAddress,
+      ethTokenAddress: _,
       ...otherDeployedTokenInfo
     } = deployedTokenInfo
     return {

--- a/cli/index.js
+++ b/cli/index.js
@@ -23,7 +23,8 @@ const { DangerDeployMyERC20 } = require('./commands/danger-deploy-myerc20')
 const {
   TransferETHERC20ToNear,
   TransferEthERC20FromNear,
-  DeployToken
+  DeployToken,
+  getEthErc20Balance
 } = require('rainbow-bridge-testing')
 const { ETHDump } = require('./commands/eth-dump')
 const { NearDump } = require('./commands/near-dump')
@@ -644,7 +645,28 @@ RainbowConfig.addOptions(
   ]
 )
 
-// Testing command
+// Testing commands
+const testingCommand = program
+  .command('TESTING')
+  .description(
+    'Commands that should only be used for testing purpose.'
+  )
+
+RainbowConfig.addOptions(
+  testingCommand
+    .command('get-eth-erc20-balance <eth_secret_key>')
+    .description('Get ERC20 balance on Ethereum.'),
+  async (ethSecretKey, args) => {
+    await getEthErc20Balance({ ethSecretKey, ...args })
+  },
+  [
+    'eth-node-url',
+    'eth-erc20-address',
+    'eth-erc20-abi-path'
+  ]
+)
+
+// Danger Testing commands
 const dangerCommand = program
   .command('DANGER')
   .description(

--- a/cli/index.js
+++ b/cli/index.js
@@ -280,27 +280,46 @@ program.version(require('./package.json').version)
 program.command('clean').action(CleanCommand.execute)
 
 RainbowConfig.addOptions(
-  program.command('prepare').action(PrepareCommand.execute),
+  program.command('prepare'),
+  PrepareCommand.execute,
   ['core-src', 'nearup-src']
 )
 
-program.command('status').action(StatusCommand.execute)
+RainbowConfig.addOptions(
+  program.command('status'),
+  StatusCommand.execute,
+  [
+    'near-network-id',
+    'near-node-url',
+    'near-master-account',
+    'near-master-sk',
+    'near-client-account',
+    'near-client-sk',
+    'near-prover-account',
+    'near-prover-sk',
+    'eth-node-url',
+    'eth-master-sk'
+  ]
+)
 
 // Maintainer commands.
-
 const startCommand = program.command('start')
 
-startCommand.command('near-node').action(StartLocalNearNodeCommand.execute)
+RainbowConfig.addOptions(
+  startCommand.command('near-node'),
+  StartLocalNearNodeCommand.execute,
+  []
+)
 
 RainbowConfig.addOptions(
-  startCommand.command('ganache').action(StartGanacheNodeCommand.execute),
+  startCommand.command('ganache'),
+  StartGanacheNodeCommand.execute,
   ['daemon']
 )
 
 RainbowConfig.addOptions(
-  startCommand
-    .command('eth2near-relay')
-    .action(StartEth2NearRelayCommand.execute),
+  startCommand.command('eth2near-relay'),
+  StartEth2NearRelayCommand.execute,
   [
     'near-master-account',
     'near-master-sk',
@@ -312,9 +331,8 @@ RainbowConfig.addOptions(
 )
 
 RainbowConfig.addOptions(
-  startCommand
-    .command('near2eth-relay')
-    .action(StartNear2EthRelayCommand.execute),
+  startCommand.command('near2eth-relay'),
+  StartNear2EthRelayCommand.execute,
   [
     'eth-node-url',
     'eth-master-sk',
@@ -331,7 +349,8 @@ RainbowConfig.addOptions(
 )
 
 RainbowConfig.addOptions(
-  startCommand.command('bridge-watchdog').action(StartWatchdogCommand.execute),
+  startCommand.command('bridge-watchdog'),
+  StartWatchdogCommand.execute,
   [
     'eth-node-url',
     'eth-master-sk',
@@ -344,25 +363,48 @@ RainbowConfig.addOptions(
 
 const stopCommand = program.command('stop')
 
-stopCommand.command('all').action(StopManagedProcessCommand.execute)
+RainbowConfig.addOptions(
+  stopCommand.command('all'),
+  StopManagedProcessCommand.execute,
+  []
+)
 
-stopCommand.command('near-node').action(StopManagedProcessCommand.execute)
+RainbowConfig.addOptions(
+  stopCommand.command('near-node'),
+  StopManagedProcessCommand.execute,
+  []
+)
 
-stopCommand.command('ganache').action(StopManagedProcessCommand.execute)
+RainbowConfig.addOptions(
+  stopCommand.command('ganache'),
+  StopManagedProcessCommand.execute,
+  []
+)
 
-stopCommand.command('eth2near-relay').action(StopManagedProcessCommand.execute)
+RainbowConfig.addOptions(
+  stopCommand.command('eth2near-relay'),
+  StopManagedProcessCommand.execute,
+  [])
 
-stopCommand.command('near2eth-relay').action(StopManagedProcessCommand.execute)
+RainbowConfig.addOptions(
+  stopCommand.command('near2eth-relay'),
+  StopManagedProcessCommand.execute,
+  []
+)
 
-stopCommand.command('bridge-watchdog').action(StopManagedProcessCommand.execute)
+RainbowConfig.addOptions(
+  stopCommand.command('bridge-watchdog'),
+  StopManagedProcessCommand.execute,
+  []
+)
 
 RainbowConfig.addOptions(
   program
     .command('init-near-contracts')
     .description(
       'Deploys and initializes Near Client and Near Prover contracts to NEAR blockchain.'
-    )
-    .action(InitNearContracts.execute),
+    ),
+  InitNearContracts.execute,
   [
     'near-network-id',
     'near-node-url',
@@ -387,8 +429,8 @@ RainbowConfig.addOptions(
     .command('init-eth-ed25519')
     .description(
       'Deploys and initializes ED25519 Solidity contract. It replaces missing precompile.'
-    )
-    .action(InitEthEd25519.execute),
+    ),
+  InitEthEd25519.execute,
   [
     'eth-node-url',
     'eth-master-sk',
@@ -401,8 +443,8 @@ RainbowConfig.addOptions(
 RainbowConfig.addOptions(
   program
     .command('init-eth-client')
-    .description('Deploys and initializes EthClient.')
-    .action(InitEthClient.execute),
+    .description('Deploys and initializes EthClient.'),
+  InitEthClient.execute,
   [
     'eth-node-url',
     'eth-master-sk',
@@ -419,8 +461,8 @@ RainbowConfig.addOptions(
 RainbowConfig.addOptions(
   program
     .command('init-eth-prover')
-    .description('Deploys and initializes EthProver.')
-    .action(InitEthProver.execute),
+    .description('Deploys and initializes EthProver.'),
+  InitEthProver.execute,
   [
     'eth-node-url',
     'eth-master-sk',
@@ -438,8 +480,8 @@ RainbowConfig.addOptions(
     .command('init-near-token-factory')
     .description(
       'Deploys and initializes token factory to NEAR blockchain. Requires locker on Ethereum side.'
-    )
-    .action(InitNearTokenFactory.execute),
+    ),
+  InitNearTokenFactory.execute,
   [
     'near-token-factory-account',
     'near-token-factory-sk',
@@ -452,8 +494,8 @@ RainbowConfig.addOptions(
 RainbowConfig.addOptions(
   program
     .command('deploy-token <token_name> <token_address>')
-    .description('Deploys and initializes token on NEAR.')
-    .action(DeployToken.execute),
+    .description('Deploys and initializes token on NEAR.'),
+  DeployToken.execute,
   ['near-token-factory-account']
 )
 
@@ -462,8 +504,8 @@ RainbowConfig.addOptions(
     .command('init-eth-locker')
     .description(
       'Deploys and initializes locker contract on Ethereum blockchain. Requires mintable fungible token on Near side.'
-    )
-    .action(InitEthLocker.execute),
+    ),
+  InitEthLocker.execute,
   [
     'eth-node-url',
     'eth-master-sk',
@@ -481,8 +523,8 @@ RainbowConfig.addOptions(
     .command('init-eth-erc20')
     .description(
       'Deploys and initializes ERC20 contract on Ethereum blockchain.'
-    )
-    .action(InitEthErc20.execute),
+    ),
+  InitEthErc20.execute,
   [
     'eth-node-url',
     'eth-master-sk',
@@ -495,7 +537,6 @@ RainbowConfig.addOptions(
 RainbowConfig.addOptions(
   program
     .command('transfer-eth-erc20-to-near')
-    .action(TransferETHERC20ToNear.execute)
     .option('--amount <amount>', 'Amount of ERC20 tokens to transfer')
     .option(
       '--eth-sender-sk <eth_sender_sk>',
@@ -509,6 +550,7 @@ RainbowConfig.addOptions(
       '--token-name <token_name>',
       'Specific ERC20 token that is already bound by `deploy-token`.'
     ),
+  TransferETHERC20ToNear.execute,
   [
     'eth-node-url',
     'eth-erc20-address',
@@ -528,7 +570,6 @@ RainbowConfig.addOptions(
 RainbowConfig.addOptions(
   program
     .command('transfer-eth-erc20-from-near')
-    .action(TransferEthERC20FromNear.execute)
     .option('--amount <amount>', 'Amount of ERC20 tokens to transfer')
     .option(
       '--near-sender-account <near_sender_account>',
@@ -546,6 +587,7 @@ RainbowConfig.addOptions(
       '--token-name <token_name>',
       'Specific ERC20 token that is already bound by `deploy-token`.'
     ),
+  TransferEthERC20FromNear.execute,
   [
     'near-node-url',
     'near-network-id',
@@ -576,8 +618,8 @@ RainbowConfig.addOptions(
     .command('submit_invalid_near_block')
     .description(
       'Fetch latest near block, randomly mutate one byte and submit to NearBridge'
-    )
-    .action(DangerSubmitInvalidNearBlock.execute),
+    ),
+  DangerSubmitInvalidNearBlock.execute,
   [
     'eth-node-url',
     'eth-master-sk',
@@ -595,24 +637,27 @@ RainbowConfig.addOptions(
 RainbowConfig.addOptions(
   dangerCommand
     .command('deploy_test_erc20')
-    .description('Deploys MyERC20')
-    .action(DangerDeployMyERC20.execute),
+    .description('Deploys MyERC20'),
+  DangerDeployMyERC20.execute,
   ['eth-node-url', 'eth-master-sk', 'eth-erc20-abi-path', 'eth-gas-multiplier']
 )
 
-program
-  .command('eth-dump <kind_of_data>')
-  .option('--eth-node-url <eth_node_url>', 'ETH node API url')
-  .option('--path <path>', 'Dir path to dump eth data')
-  .option(
-    '--start-block <start_block>',
-    'Start block number (inclusive), default to be 4.3K blocks away from start block'
-  )
-  .option(
-    '--end-block <end_block>',
-    'End block number (inclusive), default to be latest block'
-  )
-  .action(ETHDump.execute)
+RainbowConfig.addOptions(
+  program
+    .command('eth-dump <kind_of_data>')
+    .option('--eth-node-url <eth_node_url>', 'ETH node API url')
+    .option('--path <path>', 'Dir path to dump eth data')
+    .option(
+      '--start-block <start_block>',
+      'Start block number (inclusive), default to be 4.3K blocks away from start block'
+    )
+    .option(
+      '--end-block <end_block>',
+      'End block number (inclusive), default to be latest block'
+    ),
+  ETHDump.execute,
+  []
+)
 
 RainbowConfig.addOptions(
   program
@@ -621,10 +666,11 @@ RainbowConfig.addOptions(
     .option(
       '--num-blocks <num_blocks>',
       'Number of blocks to dump, default: 100'
-    )
-    .action(NearDump.execute),
+    ),
+  NearDump.execute,
   ['near-node-url']
 )
+
 ;(async () => {
   await program.parseAsync(process.argv)
 })()

--- a/cli/index.js
+++ b/cli/index.js
@@ -503,8 +503,8 @@ RainbowConfig.addOptions(
   program
     .command('deploy-token <token_name> <eth_token_address>')
     .description('Deploys and initializes token on NEAR.'),
-  (tokenName, ethTokenAddress, args) => {
-    const deployedTokenInfo = DeployToken.execute({ tokenName, ethTokenAddress, ...args })
+  async (tokenName, ethTokenAddress, args) => {
+    const deployedTokenInfo = await DeployToken.execute({ tokenName, ethTokenAddress, ...args })
     if (!deployedTokenInfo) {
       return null
     }

--- a/cli/index.js
+++ b/cli/index.js
@@ -636,6 +636,7 @@ RainbowConfig.addOptions(
     'near-network-id',
     'near-token-factory-account',
     'eth-node-url',
+    'eth-master-sk',
     'eth-erc20-abi-path',
     'eth-locker-address',
     'eth-locker-abi-path',

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const path = require('path')
+const changeCase = require('change-case')
 const { program } = require('commander')
 
 const { CleanCommand } = require('./commands/clean')
@@ -514,8 +515,8 @@ RainbowConfig.addOptions(
       ...otherDeployedTokenInfo
     } = deployedTokenInfo
     return {
-      [`near-${args.tokenName}-account`]: nearTokenAccount,
-      [`eth-${args.tokenName}-address`]: ethTokenAddress,
+      [`near${changeCase.capitalCase(tokenName)}Account`]: nearTokenAccount,
+      [`eth${changeCase.capitalCase(tokenName)}Address`]: ethTokenAddress,
       ...otherDeployedTokenInfo
     }
   },

--- a/cli/init/eth-contracts.js
+++ b/cli/init/eth-contracts.js
@@ -1,6 +1,6 @@
 const BN = require('bn.js')
 const fs = require('fs')
-const { Web3, RainbowConfig, normalizeEthKey } = require('rainbow-bridge-utils')
+const { Web3, normalizeEthKey } = require('rainbow-bridge-utils')
 
 class EthContractInitializer {
   async execute (contractName, args, gas) {

--- a/cli/init/eth-contracts.js
+++ b/cli/init/eth-contracts.js
@@ -3,163 +3,228 @@ const fs = require('fs')
 const { Web3, normalizeEthKey } = require('rainbow-bridge-utils')
 
 class EthContractInitializer {
-  async execute (contractName, args, gas) {
-    const address = 'eth-' + contractName + '-address'
-    const abiPath = RainbowConfig.getParam('eth-' + contractName + '-abi-path')
-    const binPath = RainbowConfig.getParam('eth-' + contractName + '-bin-path')
-    if (!abiPath || !binPath) {
-      return false
+  async execute ({
+    args,
+    gas,
+    ethNodeUrl,
+    ethMasterSk,
+    ethContractAbiPath,
+    ethContractBinPath,
+    ethGasMultiplier
+  }) {
+    let ethContractAddress
+    if (!ethContractAbiPath || !ethContractBinPath) {
+      return null
     }
 
     try {
-      const web3 = new Web3(RainbowConfig.getParam('eth-node-url'))
+      const web3 = new Web3(ethNodeUrl)
       let ethMasterAccount = web3.eth.accounts.privateKeyToAccount(
-        normalizeEthKey(RainbowConfig.getParam('eth-master-sk'))
+        normalizeEthKey(ethMasterSk)
       )
       web3.eth.accounts.wallet.add(ethMasterAccount)
       web3.eth.defaultAccount = ethMasterAccount.address
       ethMasterAccount = ethMasterAccount.address
 
-      console.log('Deploying ETH contract', contractName)
+      console.log('Deploying ETH contract')
       const tokenContract = new web3.eth.Contract(
-        JSON.parse(fs.readFileSync(abiPath))
+        JSON.parse(fs.readFileSync(ethContractAbiPath))
       )
       const txContract = await tokenContract
         .deploy({
-          data: '0x' + fs.readFileSync(binPath),
+          data: '0x' + fs.readFileSync(ethContractBinPath),
           arguments: args
         })
         .send({
           from: ethMasterAccount,
-          gas: gas,
-          gasPrice: new BN(await web3.eth.getGasPrice()).mul(
-            new BN(RainbowConfig.getParam('eth-gas-multiplier'))
-          )
+          gas,
+          gasPrice: new BN(await web3.eth.getGasPrice()).mul(new BN(ethGasMultiplier))
         })
-      console.log(
-        'Deployed ETH contract',
-        contractName,
-        'to',
-        `${txContract.options.address}`
-      )
-      RainbowConfig.setParam(
-        address,
-        normalizeEthKey(txContract.options.address)
-      )
-      RainbowConfig.saveConfig()
+      ethContractAddress = normalizeEthKey(txContract.options.address)
+      console.log(`Deployed ETH contract to ${ethContractAddress}`)
       try {
         // Only WebSocket provider can close.
         web3.currentProvider.connection.close()
       } catch (e) {}
     } catch (e) {
       console.log(e)
-      return false
+      return null
     }
-    return true
+    return { ethContractAddress }
   }
 }
 
 class InitEthEd25519 {
-  static async execute () {
+  static async execute ({
+    ethNodeUrl,
+    ethMasterSk,
+    ethEd25519AbiPath,
+    ethEd25519BinPath,
+    ethGasMultiplier
+  }) {
     const ethContractInitializer = new EthContractInitializer()
-    const contractName = 'ed25519'
     const success = await ethContractInitializer.execute(
-      contractName,
-      [],
-      5000000
+      {
+        args: [],
+        gas: 5000000,
+        ethContractAbiPath: ethEd25519AbiPath,
+        ethContractBinPath: ethEd25519BinPath,
+        ethNodeUrl,
+        ethMasterSk,
+        ethGasMultiplier
+      }
     )
     if (!success) {
-      console.log("Can't deploy", contractName)
+      console.log("Can't deploy", ethEd25519AbiPath)
       process.exit(1)
+    }
+    return {
+      ethEd25519Address: success.ethContractAddress
     }
   }
 }
 
 class InitEthErc20 {
-  static async execute () {
+  static async execute ({
+    ethNodeUrl,
+    ethMasterSk,
+    ethErc20AbiPath,
+    ethErc20BinPath,
+    ethGasMultiplier
+  }) {
     const ethContractInitializer = new EthContractInitializer()
-    const contractName = 'erc20'
     const success = await ethContractInitializer.execute(
-      contractName,
-      [],
-      3000000
+      {
+        args: [],
+        gas: 3000000,
+        ethContractAbiPath: ethErc20AbiPath,
+        ethContractBinPath: ethErc20BinPath,
+        ethNodeUrl,
+        ethMasterSk,
+        ethGasMultiplier
+      }
     )
     if (!success) {
-      console.log("Can't deploy", contractName)
+      console.log("Can't deploy", ethErc20AbiPath)
       process.exit(1)
+    }
+    return {
+      ethErc20Address: success.ethContractAddress
     }
   }
 }
 
 class InitEthLocker {
-  static async execute () {
+  static async execute ({
+    ethNodeUrl,
+    ethMasterSk,
+    nearTokenFactoryAccount,
+    ethProverAddress,
+    ethLockerAbiPath,
+    ethLockerBinPath,
+    ethGasMultiplier
+  }) {
     const ethContractInitializer = new EthContractInitializer()
-    const contractName = 'locker'
     const success = await ethContractInitializer.execute(
-      contractName,
-      [
-        Buffer.from(
-          RainbowConfig.getParam('near-token-factory-account'),
-          'utf8'
-        ),
-        RainbowConfig.getParam('eth-prover-address')
-      ],
-      5000000
+      {
+        args: [
+          Buffer.from(nearTokenFactoryAccount, 'utf8'),
+          ethProverAddress
+        ],
+        gas: 5000000,
+        ethContractAbiPath: ethLockerAbiPath,
+        ethContractBinPath: ethLockerBinPath,
+        ethNodeUrl,
+        ethMasterSk,
+        ethGasMultiplier
+      }
     )
     if (!success) {
-      console.log("Can't deploy", contractName)
+      console.log("Can't deploy", ethLockerAbiPath)
       process.exit(1)
+    }
+    return {
+      ethLockerAddress: success.ethContractAddress
     }
   }
 }
 
 class InitEthClient {
-  static async execute () {
+  static async execute ({
+    ethNodeUrl,
+    ethMasterSk,
+    ethClientLockEthAmount,
+    ethClientLockDuration,
+    ethClientReplaceDuration,
+    ethEd25519Address,
+    ethClientAbiPath,
+    ethClientBinPath,
+    ethGasMultiplier
+  }) {
     const ethContractInitializer = new EthContractInitializer()
-    const contractName = 'client'
-    const web3 = new Web3(RainbowConfig.getParam('eth-node-url'))
-    const lockEthAmount = web3.utils.toBN(
-      RainbowConfig.getParam('eth-client-lock-eth-amount')
-    )
-    const lockDuration = web3.utils.toBN(
-      RainbowConfig.getParam('eth-client-lock-duration')
-    )
+    const web3 = new Web3(ethNodeUrl)
+    const lockEthAmount = web3.utils.toBN(ethClientLockEthAmount)
+    const lockDuration = web3.utils.toBN(ethClientLockDuration)
     const replaceDuration = web3.utils
-      .toBN(RainbowConfig.getParam('eth-client-replace-duration'))
+      .toBN(ethClientReplaceDuration)
       .mul(new web3.utils.BN(1e9))
     try {
       // Only WebSocket provider can close.
       web3.currentProvider.connection.close()
     } catch (e) {}
     const success = await ethContractInitializer.execute(
-      contractName,
-      [
-        RainbowConfig.getParam('eth-ed25519-address'),
-        lockEthAmount,
-        lockDuration,
-        replaceDuration
-      ],
-      5000000
+      {
+        args: [
+          ethEd25519Address,
+          lockEthAmount,
+          lockDuration,
+          replaceDuration
+        ],
+        gas: 5000000,
+        ethContractAbiPath: ethClientAbiPath,
+        ethContractBinPath: ethClientBinPath,
+        ethNodeUrl,
+        ethMasterSk,
+        ethGasMultiplier
+      }
     )
     if (!success) {
-      console.log("Can't deploy", contractName)
+      console.log("Can't deploy", ethClientAbiPath)
       process.exit(1)
+    }
+    return {
+      ethClientAddress: success.ethContractAddress
     }
   }
 }
 
 class InitEthProver {
-  static async execute () {
+  static async execute ({
+    ethNodeUrl,
+    ethMasterSk,
+    ethClientAddress,
+    ethProverAbiPath,
+    ethProverBinPath,
+    ethGasMultiplier
+  }) {
     const ethContractInitializer = new EthContractInitializer()
-    const contractName = 'prover'
     const success = await ethContractInitializer.execute(
-      contractName,
-      [RainbowConfig.getParam('eth-client-address')],
-      3000000
+      {
+        args: [ethClientAddress],
+        gas: 3000000,
+        ethContractAbiPath: ethProverAbiPath,
+        ethContractBinPath: ethProverBinPath,
+        ethNodeUrl,
+        ethMasterSk,
+        ethGasMultiplier
+      }
     )
     if (!success) {
-      console.log("Can't deploy", contractName)
+      console.log("Can't deploy", ethProverAbiPath)
       process.exit(1)
+    }
+    return {
+      ethProverAddress: success.ethContractAddress
     }
   }
 }

--- a/cli/init/near-contracts.js
+++ b/cli/init/near-contracts.js
@@ -32,14 +32,12 @@ class InitNearContracts {
         'Key to call Near Client contract is not specified. Reusing master key.'
       )
       nearClientSk = nearMasterSk
-      RainbowConfig.setParam('near-client-sk', nearMasterSk)
     }
     if (!nearProverSk) {
       console.log(
         'Key to call Near Prover contract is not specified. Reusing master key.'
       )
       nearProverSk = nearMasterSk
-      RainbowConfig.setParam('near-prover-sk', nearMasterSk)
     }
     const nearClientPk = nearAPI.KeyPair.fromString(nearClientSk).getPublicKey()
     const nearProverPk = nearAPI.KeyPair.fromString(nearProverSk).getPublicKey()
@@ -106,8 +104,11 @@ class InitNearContracts {
       nearProverAccount
     )
     await proverContract.maybeInitialize(nearClientAccount)
-    RainbowConfig.saveConfig()
-    process.exit(0)
+
+    return {
+      nearClientSk,
+      nearProverSk
+    }
   }
 }
 

--- a/cli/init/near-contracts.js
+++ b/cli/init/near-contracts.js
@@ -105,6 +105,7 @@ class InitNearContracts {
     )
     await proverContract.maybeInitialize(nearClientAccount)
 
+    robustWeb3.destroy()
     return {
       nearClientSk,
       nearProverSk

--- a/cli/init/near-token-factory.js
+++ b/cli/init/near-token-factory.js
@@ -1,6 +1,5 @@
 const {
   nearAPI,
-  RainbowConfig,
   maybeCreateAccount,
   verifyAccount
 } = require('rainbow-bridge-utils')
@@ -8,78 +7,72 @@ const { BN } = require('ethereumjs-util')
 const { DeployToken } = require('rainbow-bridge-testing')
 
 class InitNearTokenFactory {
-  static async execute () {
-    const masterAccount = RainbowConfig.getParam('near-master-account')
-    const masterSk = RainbowConfig.getParam('near-master-sk')
-    const tokenFactoryAccount = RainbowConfig.getParam(
-      'near-token-factory-account'
-    )
-    let tokenSk = RainbowConfig.maybeGetParam('near-token-factory-sk')
-    if (!tokenSk) {
+  static async execute ({
+    nearMasterAccount,
+    nearMasterSk,
+    nearTokenFactoryAccount,
+    nearTokenFactorySk,
+    nearTokenFactoryContractPath,
+    nearTokenFactoryInitBalance,
+    nearProverAccount,
+    nearNodeUrl,
+    nearNetworkId,
+    ethLockerAddress,
+    ethErc20Address
+  }) {
+    if (!nearTokenFactorySk) {
       console.log(
         'Secret key for fungible token is not specified. Reusing master secret key.'
       )
-      tokenSk = masterSk
-      RainbowConfig.setParam('near-token-factory-sk', tokenSk)
+      nearTokenFactorySk = nearMasterSk
+      RainbowConfig.setParam('near-token-factory-sk', nearTokenFactorySk)
     }
-    const tokenContractPath = RainbowConfig.getParam(
-      'near-token-factory-contract-path'
-    )
-    const tokenInitBalance = RainbowConfig.getParam(
-      'near-token-factory-init-balance'
-    )
-    const proverAccount = RainbowConfig.getParam('near-prover-account')
-
-    const nearNodeUrl = RainbowConfig.getParam('near-node-url')
-    const nearNetworkId = RainbowConfig.getParam('near-network-id')
-
-    const tokenPk = nearAPI.KeyPair.fromString(tokenSk).getPublicKey()
+    const nearTokenFactoryPk = nearAPI.KeyPair.fromString(nearTokenFactorySk).getPublicKey()
 
     const keyStore = new nearAPI.keyStores.InMemoryKeyStore()
     await keyStore.setKey(
       nearNetworkId,
-      masterAccount,
-      nearAPI.KeyPair.fromString(masterSk)
+      nearMasterAccount,
+      nearAPI.KeyPair.fromString(nearMasterSk)
     )
     await keyStore.setKey(
       nearNetworkId,
-      tokenFactoryAccount,
-      nearAPI.KeyPair.fromString(tokenSk)
+      nearTokenFactoryAccount,
+      nearAPI.KeyPair.fromString(nearTokenFactorySk)
     )
     const near = await nearAPI.connect({
       nodeUrl: nearNodeUrl,
       networkId: nearNetworkId,
-      masterAccount: masterAccount,
+      masterAccount: nearMasterAccount,
       deps: { keyStore: keyStore }
     })
 
-    await verifyAccount(near, masterAccount)
+    await verifyAccount(near, nearMasterAccount)
     console.log('Deploying token contract.')
     await maybeCreateAccount(
       near,
-      masterAccount,
-      tokenFactoryAccount,
-      tokenPk,
-      tokenInitBalance,
-      tokenContractPath
+      nearMasterAccount,
+      nearTokenFactoryAccount,
+      nearTokenFactoryPk,
+      nearTokenFactoryInitBalance,
+      nearTokenFactoryContractPath
     )
     const tokenFactoryContract = new nearAPI.Contract(
-      new nearAPI.Account(near.connection, tokenFactoryAccount),
-      tokenFactoryAccount,
+      new nearAPI.Account(near.connection, nearTokenFactoryAccount),
+      nearTokenFactoryAccount,
       {
         changeMethods: ['new', 'deploy_bridge_token'],
         viewMethods: ['get_bridge_token_account_id']
       }
     )
-    const lockerAddress = RainbowConfig.getParam('eth-locker-address')
     try {
       // Try initializing the factory.
       await tokenFactoryContract.new(
         {
-          prover_account: proverAccount,
-          locker_address: lockerAddress.startsWith('0x')
-            ? lockerAddress.substr(2)
-            : lockerAddress
+          prover_account: nearProverAccount,
+          locker_address: ethLockerAddress.startsWith('0x')
+            ? ethLockerAddress.substr(2)
+            : ethLockerAddress
         },
         new BN('300000000000000')
       )
@@ -88,7 +81,7 @@ class InitNearTokenFactory {
       process.exit(1)
     }
 
-    DeployToken.execute('erc20', RainbowConfig.getParam('eth-erc20-address'))
+    DeployToken.execute('erc20', ethErc20Address)
   }
 }
 

--- a/cli/init/near-token-factory.js
+++ b/cli/init/near-token-factory.js
@@ -25,7 +25,6 @@ class InitNearTokenFactory {
         'Secret key for fungible token is not specified. Reusing master secret key.'
       )
       nearTokenFactorySk = nearMasterSk
-      RainbowConfig.setParam('near-token-factory-sk', nearTokenFactorySk)
     }
     const nearTokenFactoryPk = nearAPI.KeyPair.fromString(nearTokenFactorySk).getPublicKey()
 
@@ -81,7 +80,16 @@ class InitNearTokenFactory {
       process.exit(1)
     }
 
-    DeployToken.execute('erc20', ethErc20Address)
+    return DeployToken.execute({
+      tokenName: 'erc20',
+      ethTokenAddress: ethErc20Address,
+      nearNodeUrl,
+      nearNetworkId,
+      nearMasterAccount,
+      nearMasterSk,
+      nearTokenFactoryAccount,
+      nearTokenFactorySk
+    })
   }
 }
 

--- a/cli/init/near-token-factory.js
+++ b/cli/init/near-token-factory.js
@@ -80,7 +80,7 @@ class InitNearTokenFactory {
       process.exit(1)
     }
 
-    return DeployToken.execute({
+    const deployedTokenInfo = await DeployToken.execute({
       tokenName: 'erc20',
       ethTokenAddress: ethErc20Address,
       nearNodeUrl,
@@ -90,6 +90,19 @@ class InitNearTokenFactory {
       nearTokenFactoryAccount,
       nearTokenFactorySk
     })
+    if (!deployedTokenInfo) {
+      return null
+    }
+    const {
+      nearTokenAccount,
+      ethTokenAddress,
+      ...otherDeployedTokenInfo
+    } = deployedTokenInfo
+    return {
+      nearErc20Account: nearTokenAccount,
+      ethErc20Address: ethTokenAddress,
+      ...otherDeployedTokenInfo
+    }
   }
 }
 

--- a/eth2near/eth2near-block-relay/index.js
+++ b/eth2near/eth2near-block-relay/index.js
@@ -1,247 +1,14 @@
 const path = require('path')
 const exec = require('child_process').exec
 const BN = require('bn.js')
-const { RobustWeb3, sleep, txnStatus, nearAPI, RainbowConfig } = require('rainbow-bridge-utils')
+const { RobustWeb3, sleep, txnStatus } = require('rainbow-bridge-utils')
 const { web3BlockToRlp, EthOnNearClientContract } = require('./eth-on-near-client')
 const { EthOnNearProverContract } = require('./eth-on-near-prover')
 const { EthProofExtractor, logFromWeb3, receiptFromWeb3 } = require('./eth-proof-extractor')
+
+// TODO: enable configuration
 const MAX_SUBMIT_BLOCK = 10
 const BRIDGE_SRC_DIR = path.join(__dirname, '..', '..')
-
-// TODO @frol use config
-const LIBS_SOL_SRC_DIR = path.join(
-  BRIDGE_SRC_DIR,
-  'node_modules/rainbow-bridge-sol'
-)
-const LIBS_RS_SRC_DIR = path.join(
-  BRIDGE_SRC_DIR,
-  'node_modules/rainbow-bridge-rs'
-)
-const LIBS_TC_SRC_DIR = path.join(
-  BRIDGE_SRC_DIR,
-  'node_modules/rainbow-token-connector'
-)
-
-RainbowConfig.declareOption(
-  'near-network-id',
-  'The identifier of the NEAR network that the given NEAR node is expected to represent.'
-)
-RainbowConfig.declareOption('near-node-url', 'The URL of the NEAR node.')
-RainbowConfig.declareOption('eth-node-url', 'The URL of the Ethereum node.')
-RainbowConfig.declareOption(
-  'near-master-account',
-  'The account of the master account on NEAR blockchain that can be used to deploy and initialize the test contracts.' +
-    ' This account will also own the initial supply of the fungible tokens.'
-)
-RainbowConfig.declareOption(
-  'near-master-sk',
-  'The secret key of the master account on NEAR blockchain.'
-)
-RainbowConfig.declareOption(
-  'eth-master-sk',
-  'The secret key of the master account on Ethereum blockchain.'
-)
-RainbowConfig.declareOption(
-  'near-client-account',
-  'The account of the Near Client contract that can be used to accept ETH headers.',
-  'rainbow_bridge_eth_on_near_client'
-)
-RainbowConfig.declareOption(
-  'near-client-sk',
-  'The secret key of the Near Client account. If not specified will use master SK.'
-)
-RainbowConfig.declareOption(
-  'near-client-contract-path',
-  'The path to the Wasm file containing the Near Client contract.',
-  path.join(LIBS_RS_SRC_DIR, 'res/eth_client.wasm')
-)
-RainbowConfig.declareOption(
-  'near-client-init-balance',
-  'The initial balance of Near Client contract in femtoNEAR.',
-  '100000000000000000000000000'
-)
-RainbowConfig.declareOption(
-  'near-client-validate-ethash',
-  'Whether validate ethash of submitted eth block, should set to true on mainnet and false on PoA testnets',
-  'true'
-)
-RainbowConfig.declareOption(
-  'near-client-trusted-signer',
-  'When non empty, deploy as trusted-signer mode where only tursted signer can submit blocks to client',
-  ''
-)
-RainbowConfig.declareOption(
-  'near-prover-account',
-  'The account of the Near Prover contract that can be used to accept ETH headers.',
-  'rainbow_bridge_eth_on_near_prover'
-)
-RainbowConfig.declareOption(
-  'near-prover-sk',
-  'The secret key of the Near Prover account. If not specified will use master SK.'
-)
-RainbowConfig.declareOption(
-  'near-prover-contract-path',
-  'The path to the Wasm file containing the Near Prover contract.',
-  path.join(LIBS_RS_SRC_DIR, 'res/eth_prover.wasm')
-)
-RainbowConfig.declareOption(
-  'near-prover-init-balance',
-  'The initial balance of Near Prover contract in femtoNEAR.',
-  '100000000000000000000000000'
-)
-RainbowConfig.declareOption(
-  'daemon',
-  'Whether the process should be launched as a daemon.',
-  'true',
-  true
-)
-RainbowConfig.declareOption(
-  'core-src',
-  'Path to the nearcore source. It will be downloaded if not provided.',
-  ''
-)
-RainbowConfig.declareOption(
-  'nearup-src',
-  'Path to the nearup source. It will be downloaded if not provided.',
-  ''
-)
-RainbowConfig.declareOption(
-  'eth-gas-multiplier',
-  'How many times more in Ethereum gas are we willing to overpay.',
-  '1'
-)
-
-// User-specific arguments.
-RainbowConfig.declareOption(
-  'near-token-factory-account',
-  'The account of the token factory contract that will be used to mint tokens locked on Ethereum.',
-  'neartokenfactory'
-)
-RainbowConfig.declareOption(
-  'near-token-factory-sk',
-  'The secret key of the token factory account. If not specified will use master SK.'
-)
-RainbowConfig.declareOption(
-  'near-token-factory-contract-path',
-  'The path to the Wasm file containing the token factory contract.',
-  path.join(LIBS_TC_SRC_DIR, 'res/bridge_token_factory.wasm')
-)
-RainbowConfig.declareOption(
-  'near-token-factory-init-balance',
-  'The initial balance of token factory contract in yoctoNEAR.',
-  '1000000000000000000000000000'
-)
-RainbowConfig.declareOption(
-  'eth-locker-address',
-  'ETH address of the locker contract.'
-)
-RainbowConfig.declareOption(
-  'eth-locker-abi-path',
-  'Path to the .abi file defining Ethereum locker contract. This contract works in pair with mintable fungible token on NEAR blockchain.',
-  path.join(LIBS_TC_SRC_DIR, 'res/BridgeTokenFactory.full.abi')
-)
-RainbowConfig.declareOption(
-  'eth-locker-bin-path',
-  'Path to the .bin file defining Ethereum locker contract. This contract works in pair with mintable fungible token on NEAR blockchain.',
-  path.join(LIBS_TC_SRC_DIR, 'res/BridgeTokenFactory.full.bin')
-)
-RainbowConfig.declareOption(
-  'eth-erc20-address',
-  'ETH address of the ERC20 contract.'
-)
-RainbowConfig.declareOption(
-  'eth-erc20-abi-path',
-  'Path to the .abi file defining Ethereum ERC20 contract.',
-  path.join(LIBS_TC_SRC_DIR, 'res/TToken.full.abi')
-)
-RainbowConfig.declareOption(
-  'eth-erc20-bin-path',
-  'Path to the .bin file defining Ethereum ERC20 contract.',
-  path.join(LIBS_TC_SRC_DIR, 'res/TToken.full.bin')
-)
-RainbowConfig.declareOption(
-  'eth-ed25519-address',
-  'ETH address of the ED25519 contract.'
-)
-RainbowConfig.declareOption(
-  'eth-ed25519-abi-path',
-  'Path to the .abi file defining Ethereum ED25519 contract.',
-  path.join(LIBS_SOL_SRC_DIR, 'nearbridge/dist/Ed25519.full.abi')
-)
-RainbowConfig.declareOption(
-  'eth-ed25519-bin-path',
-  'Path to the .bin file defining Ethereum ED25519 contract.',
-  path.join(LIBS_SOL_SRC_DIR, 'nearbridge/dist/Ed25519.full.bin')
-)
-RainbowConfig.declareOption(
-  'eth-client-lock-eth-amount',
-  'Amount of Ether that should be temporarily locked when submitting a new header to EthClient, in wei.',
-  '100000000000000000000'
-)
-RainbowConfig.declareOption(
-  'eth-client-lock-duration',
-  'The challenge window during which anyone can challenge an incorrect ED25519 signature of the Near block, in EthClient, in seconds.',
-  14400
-)
-RainbowConfig.declareOption(
-  'eth-client-replace-duration',
-  'Minimum time difference required to replace a block during challenge period, in EthClient, in seconds.',
-  18000
-)
-RainbowConfig.declareOption(
-  'eth-client-address',
-  'ETH address of the EthClient contract.'
-)
-RainbowConfig.declareOption(
-  'eth-client-abi-path',
-  'Path to the .abi file defining Ethereum Client contract.',
-  path.join(LIBS_SOL_SRC_DIR, 'nearbridge/dist/NearBridge.full.abi')
-)
-RainbowConfig.declareOption(
-  'eth-client-bin-path',
-  'Path to the .bin file defining Ethereum Client contract.',
-  path.join(LIBS_SOL_SRC_DIR, 'nearbridge/dist/NearBridge.full.bin')
-)
-RainbowConfig.declareOption(
-  'eth-prover-address',
-  'ETH address of the EthProver contract.'
-)
-RainbowConfig.declareOption(
-  'eth-prover-abi-path',
-  'Path to the .abi file defining Ethereum Prover contract.',
-  path.join(LIBS_SOL_SRC_DIR, 'nearprover/dist/NearProver.full.abi')
-)
-RainbowConfig.declareOption(
-  'eth-prover-bin-path',
-  'Path to the .bin file defining Ethereum Prover contract.',
-  path.join(LIBS_SOL_SRC_DIR, 'nearprover/dist/NearProver.full.bin')
-)
-RainbowConfig.declareOption(
-  'near2eth-relay-min-delay',
-  "Minimum number of seconds to wait if the relay can't submit a block right away.",
-  '1'
-)
-RainbowConfig.declareOption(
-  'near2eth-relay-max-delay',
-  "Maximum number of seconds to wait if the relay can't submit a block right away.",
-  '600'
-)
-RainbowConfig.declareOption(
-  'near2eth-relay-error-delay',
-  'Number of seconds to wait before retrying if there is an error.',
-  '1'
-)
-RainbowConfig.declareOption(
-  'watchdog-delay',
-  'Number of seconds to wait after validating all signatures.',
-  '300'
-)
-RainbowConfig.declareOption(
-  'watchdog-error-delay',
-  'Number of seconds to wait before retrying if there is an error.',
-  '1'
-)
-RainbowConfig.declareOption('near-erc20-account', 'Must be declared before set')
 
 function ethashproof (command, _callback) {
   return new Promise((resolve) =>
@@ -255,10 +22,10 @@ function ethashproof (command, _callback) {
 }
 
 class Eth2NearRelay {
-  initialize (ethClientContract, ethNodeURL) {
+  initialize (ethClientContract, { ethNodeUrl }) {
     this.ethClientContract = ethClientContract
     // @ts-ignore
-    this.robustWeb3 = new RobustWeb3(ethNodeURL)
+    this.robustWeb3 = new RobustWeb3(ethNodeUrl)
     this.web3 = this.robustWeb3.web3
   }
 
@@ -403,43 +170,45 @@ class Eth2NearRelay {
   }
 }
 
-async function runEth2NearRelay () {
-  const masterAccount = RainbowConfig.getParam('near-master-account')
-  const masterSk = RainbowConfig.getParam('near-master-sk')
-  const keyStore = new nearAPI.keyStores.InMemoryKeyStore()
-  await keyStore.setKey(
-    RainbowConfig.getParam('near-network-id'),
-    masterAccount,
-    nearAPI.KeyPair.fromString(masterSk)
-  )
-  const near = await nearAPI.connect({
-    nodeUrl: RainbowConfig.getParam('near-node-url'),
-    networkId: RainbowConfig.getParam('near-network-id'),
-    masterAccount: masterAccount,
-    deps: {
-      keyStore: keyStore
-    }
-  })
+// TODO: remove it once confurmed it is not used
+//
+// async function runEth2NearRelay () {
+//   const masterAccount = RainbowConfig.getParam('near-master-account')
+//   const masterSk = RainbowConfig.getParam('near-master-sk')
+//   const keyStore = new nearAPI.keyStores.InMemoryKeyStore()
+//   await keyStore.setKey(
+//     RainbowConfig.getParam('near-network-id'),
+//     masterAccount,
+//     nearAPI.KeyPair.fromString(masterSk)
+//   )
+//   const near = await nearAPI.connect({
+//     nodeUrl: RainbowConfig.getParam('near-node-url'),
+//     networkId: RainbowConfig.getParam('near-network-id'),
+//     masterAccount: masterAccount,
+//     deps: {
+//       keyStore: keyStore
+//     }
+//   })
 
-  const relay = new Eth2NearRelay()
-  const clientContract = new EthOnNearClientContract(
-    new nearAPI.Account(near.connection, masterAccount),
-    RainbowConfig.getParam('near-client-account')
-  )
-  await clientContract.accessKeyInit()
-  console.log('Initializing eth2near-relay...')
-  relay.initialize(clientContract, RainbowConfig.getParam('eth-node-url'))
-  console.log('Starting eth2near-relay...')
-  relay.run()
-}
+//   const relay = new Eth2NearRelay()
+//   const clientContract = new EthOnNearClientContract(
+//     new nearAPI.Account(near.connection, masterAccount),
+//     RainbowConfig.getParam('near-client-account')
+//   )
+//   await clientContract.accessKeyInit()
+//   console.log('Initializing eth2near-relay...')
+//   relay.initialize(clientContract, RainbowConfig.getParam('eth-node-url'))
+//   console.log('Starting eth2near-relay...')
+//   relay.run()
+// }
 
 exports.Eth2NearRelay = Eth2NearRelay
 exports.EthProofExtractor = EthProofExtractor
 exports.ethashproof = ethashproof
 exports.EthOnNearClientContract = EthOnNearClientContract
 exports.EthOnNearProverContract = EthOnNearProverContract
-exports.runEth2NearRelay = runEth2NearRelay
 exports.logFromWeb3 = logFromWeb3
 exports.receiptFromWeb3 = receiptFromWeb3
+// exports.runEth2NearRelay = runEth2NearRelay
 
-require('make-runnable')
+// require('make-runnable')

--- a/eth2near/eth2near-block-relay/index.js
+++ b/eth2near/eth2near-block-relay/index.js
@@ -170,38 +170,6 @@ class Eth2NearRelay {
   }
 }
 
-// TODO: remove it once confurmed it is not used
-//
-// async function runEth2NearRelay () {
-//   const masterAccount = RainbowConfig.getParam('near-master-account')
-//   const masterSk = RainbowConfig.getParam('near-master-sk')
-//   const keyStore = new nearAPI.keyStores.InMemoryKeyStore()
-//   await keyStore.setKey(
-//     RainbowConfig.getParam('near-network-id'),
-//     masterAccount,
-//     nearAPI.KeyPair.fromString(masterSk)
-//   )
-//   const near = await nearAPI.connect({
-//     nodeUrl: RainbowConfig.getParam('near-node-url'),
-//     networkId: RainbowConfig.getParam('near-network-id'),
-//     masterAccount: masterAccount,
-//     deps: {
-//       keyStore: keyStore
-//     }
-//   })
-
-//   const relay = new Eth2NearRelay()
-//   const clientContract = new EthOnNearClientContract(
-//     new nearAPI.Account(near.connection, masterAccount),
-//     RainbowConfig.getParam('near-client-account')
-//   )
-//   await clientContract.accessKeyInit()
-//   console.log('Initializing eth2near-relay...')
-//   relay.initialize(clientContract, RainbowConfig.getParam('eth-node-url'))
-//   console.log('Starting eth2near-relay...')
-//   relay.run()
-// }
-
 exports.Eth2NearRelay = Eth2NearRelay
 exports.EthProofExtractor = EthProofExtractor
 exports.ethashproof = ethashproof
@@ -209,6 +177,3 @@ exports.EthOnNearClientContract = EthOnNearClientContract
 exports.EthOnNearProverContract = EthOnNearProverContract
 exports.logFromWeb3 = logFromWeb3
 exports.receiptFromWeb3 = receiptFromWeb3
-// exports.runEth2NearRelay = runEth2NearRelay
-
-// require('make-runnable')

--- a/eth2near/eth2near-block-relay/package.json
+++ b/eth2near/eth2near-block-relay/package.json
@@ -21,7 +21,6 @@
     "eth-object": "near/eth-object#54e03b8aac8208cf724e206d49ffb8bdd30451d7",
     "eth-util-lite": "near/eth-util-lite#master",
     "ethereumjs-block": "^2.2.2",
-    "make-runnable": "^1.3.8",
     "merkle-patricia-tree": "^2.1.2",
     "promisfy": "^1.2.0",
     "rainbow-bridge-utils": "1.0.0"

--- a/near2eth/near2eth-block-relay/index.js
+++ b/near2eth/near2eth-block-relay/index.js
@@ -1,12 +1,10 @@
 const fs = require('fs')
-const path = require('path')
 // @ts-ignore
 const bs58 = require('bs58')
 // @ts-ignore
 const { toBuffer } = require('eth-util-lite')
 const { BN } = require('ethereumjs-util')
 const {
-  RainbowConfig,
   sleep,
   RobustWeb3,
   normalizeEthKey,
@@ -15,251 +13,21 @@ const {
   nearAPI
 } = require('rainbow-bridge-utils')
 
-// TODO @frol use config
-const BRIDGE_SRC_DIR = __dirname
-const LIBS_SOL_SRC_DIR = path.join(
-  BRIDGE_SRC_DIR,
-  '../../node_modules/rainbow-bridge-sol'
-)
-const LIBS_RS_SRC_DIR = path.join(
-  BRIDGE_SRC_DIR,
-  '../../node_modules/rainbow-bridge-rs'
-)
-const LIBS_TC_SRC_DIR = path.join(
-  BRIDGE_SRC_DIR,
-  '../../node_modules/rainbow-token-connector'
-)
-
-RainbowConfig.declareOption(
-  'near-network-id',
-  'The identifier of the NEAR network that the given NEAR node is expected to represent.'
-)
-RainbowConfig.declareOption('near-node-url', 'The URL of the NEAR node.')
-RainbowConfig.declareOption('eth-node-url', 'The URL of the Ethereum node.')
-RainbowConfig.declareOption(
-  'near-master-account',
-  'The account of the master account on NEAR blockchain that can be used to deploy and initialize the test contracts.' +
-    ' This account will also own the initial supply of the fungible tokens.'
-)
-RainbowConfig.declareOption(
-  'near-master-sk',
-  'The secret key of the master account on NEAR blockchain.'
-)
-RainbowConfig.declareOption(
-  'eth-master-sk',
-  'The secret key of the master account on Ethereum blockchain.'
-)
-RainbowConfig.declareOption(
-  'near-client-account',
-  'The account of the Near Client contract that can be used to accept ETH headers.',
-  'rainbow_bridge_eth_on_near_client'
-)
-RainbowConfig.declareOption(
-  'near-client-sk',
-  'The secret key of the Near Client account. If not specified will use master SK.'
-)
-RainbowConfig.declareOption(
-  'near-client-contract-path',
-  'The path to the Wasm file containing the Near Client contract.',
-  path.join(LIBS_RS_SRC_DIR, 'res/eth_client.wasm')
-)
-RainbowConfig.declareOption(
-  'near-client-init-balance',
-  'The initial balance of Near Client contract in femtoNEAR.',
-  '100000000000000000000000000'
-)
-RainbowConfig.declareOption(
-  'near-client-validate-ethash',
-  'Whether validate ethash of submitted eth block, should set to true on mainnet and false on PoA testnets',
-  'true'
-)
-RainbowConfig.declareOption(
-  'near-client-trusted-signer',
-  'When non empty, deploy as trusted-signer mode where only tursted signer can submit blocks to client',
-  ''
-)
-RainbowConfig.declareOption(
-  'near-prover-account',
-  'The account of the Near Prover contract that can be used to accept ETH headers.',
-  'rainbow_bridge_eth_on_near_prover'
-)
-RainbowConfig.declareOption(
-  'near-prover-sk',
-  'The secret key of the Near Prover account. If not specified will use master SK.'
-)
-RainbowConfig.declareOption(
-  'near-prover-contract-path',
-  'The path to the Wasm file containing the Near Prover contract.',
-  path.join(LIBS_RS_SRC_DIR, 'res/eth_prover.wasm')
-)
-RainbowConfig.declareOption(
-  'near-prover-init-balance',
-  'The initial balance of Near Prover contract in femtoNEAR.',
-  '100000000000000000000000000'
-)
-RainbowConfig.declareOption(
-  'daemon',
-  'Whether the process should be launched as a daemon.',
-  'true',
-  true
-)
-RainbowConfig.declareOption(
-  'core-src',
-  'Path to the nearcore source. It will be downloaded if not provided.',
-  ''
-)
-RainbowConfig.declareOption(
-  'nearup-src',
-  'Path to the nearup source. It will be downloaded if not provided.',
-  ''
-)
-RainbowConfig.declareOption(
-  'eth-gas-multiplier',
-  'How many times more in Ethereum gas are we willing to overpay.',
-  '1'
-)
-
-// User-specific arguments.
-RainbowConfig.declareOption(
-  'near-token-factory-account',
-  'The account of the token factory contract that will be used to mint tokens locked on Ethereum.',
-  'neartokenfactory'
-)
-RainbowConfig.declareOption(
-  'near-token-factory-sk',
-  'The secret key of the token factory account. If not specified will use master SK.'
-)
-RainbowConfig.declareOption(
-  'near-token-factory-contract-path',
-  'The path to the Wasm file containing the token factory contract.',
-  path.join(LIBS_TC_SRC_DIR, 'res/bridge_token_factory.wasm')
-)
-RainbowConfig.declareOption(
-  'near-token-factory-init-balance',
-  'The initial balance of token factory contract in yoctoNEAR.',
-  '1000000000000000000000000000'
-)
-RainbowConfig.declareOption(
-  'eth-locker-address',
-  'ETH address of the locker contract.'
-)
-RainbowConfig.declareOption(
-  'eth-locker-abi-path',
-  'Path to the .abi file defining Ethereum locker contract. This contract works in pair with mintable fungible token on NEAR blockchain.',
-  path.join(LIBS_TC_SRC_DIR, 'res/BridgeTokenFactory.full.abi')
-)
-RainbowConfig.declareOption(
-  'eth-locker-bin-path',
-  'Path to the .bin file defining Ethereum locker contract. This contract works in pair with mintable fungible token on NEAR blockchain.',
-  path.join(LIBS_TC_SRC_DIR, 'res/BridgeTokenFactory.full.bin')
-)
-RainbowConfig.declareOption(
-  'eth-erc20-address',
-  'ETH address of the ERC20 contract.'
-)
-RainbowConfig.declareOption(
-  'eth-erc20-abi-path',
-  'Path to the .abi file defining Ethereum ERC20 contract.',
-  path.join(LIBS_TC_SRC_DIR, 'res/TToken.full.abi')
-)
-RainbowConfig.declareOption(
-  'eth-erc20-bin-path',
-  'Path to the .bin file defining Ethereum ERC20 contract.',
-  path.join(LIBS_TC_SRC_DIR, 'res/TToken.full.bin')
-)
-RainbowConfig.declareOption(
-  'eth-ed25519-address',
-  'ETH address of the ED25519 contract.'
-)
-RainbowConfig.declareOption(
-  'eth-ed25519-abi-path',
-  'Path to the .abi file defining Ethereum ED25519 contract.',
-  path.join(LIBS_SOL_SRC_DIR, 'nearbridge/dist/Ed25519.full.abi')
-)
-RainbowConfig.declareOption(
-  'eth-ed25519-bin-path',
-  'Path to the .bin file defining Ethereum ED25519 contract.',
-  path.join(LIBS_SOL_SRC_DIR, 'nearbridge/dist/Ed25519.full.bin')
-)
-RainbowConfig.declareOption(
-  'eth-client-lock-eth-amount',
-  'Amount of Ether that should be temporarily locked when submitting a new header to EthClient, in wei.',
-  '100000000000000000000'
-)
-RainbowConfig.declareOption(
-  'eth-client-lock-duration',
-  'The challenge window during which anyone can challenge an incorrect ED25519 signature of the Near block, in EthClient, in seconds.',
-  14400
-)
-RainbowConfig.declareOption(
-  'eth-client-replace-duration',
-  'Minimum time difference required to replace a block during challenge period, in EthClient, in seconds.',
-  18000
-)
-RainbowConfig.declareOption(
-  'eth-client-address',
-  'ETH address of the EthClient contract.'
-)
-RainbowConfig.declareOption(
-  'eth-client-abi-path',
-  'Path to the .abi file defining Ethereum Client contract.',
-  path.join(LIBS_SOL_SRC_DIR, 'nearbridge/dist/NearBridge.full.abi')
-)
-RainbowConfig.declareOption(
-  'eth-client-bin-path',
-  'Path to the .bin file defining Ethereum Client contract.',
-  path.join(LIBS_SOL_SRC_DIR, 'nearbridge/dist/NearBridge.full.bin')
-)
-RainbowConfig.declareOption(
-  'eth-prover-address',
-  'ETH address of the EthProver contract.'
-)
-RainbowConfig.declareOption(
-  'eth-prover-abi-path',
-  'Path to the .abi file defining Ethereum Prover contract.',
-  path.join(LIBS_SOL_SRC_DIR, 'nearprover/dist/NearProver.full.abi')
-)
-RainbowConfig.declareOption(
-  'eth-prover-bin-path',
-  'Path to the .bin file defining Ethereum Prover contract.',
-  path.join(LIBS_SOL_SRC_DIR, 'nearprover/dist/NearProver.full.bin')
-)
-RainbowConfig.declareOption(
-  'near2eth-relay-min-delay',
-  "Minimum number of seconds to wait if the relay can't submit a block right away.",
-  '1'
-)
-RainbowConfig.declareOption(
-  'near2eth-relay-max-delay',
-  "Maximum number of seconds to wait if the relay can't submit a block right away.",
-  '600'
-)
-RainbowConfig.declareOption(
-  'near2eth-relay-error-delay',
-  'Number of seconds to wait before retrying if there is an error.',
-  '1'
-)
-RainbowConfig.declareOption(
-  'watchdog-delay',
-  'Number of seconds to wait after validating all signatures.',
-  '300'
-)
-RainbowConfig.declareOption(
-  'watchdog-error-delay',
-  'Number of seconds to wait before retrying if there is an error.',
-  '1'
-)
-RainbowConfig.declareOption('near-erc20-account', 'Must be declared before set')
-
 class Near2EthRelay {
-  async initialize (ethMasterSk = null) {
+  async initialize ({
+    nearNodeUrl,
+    nearNetworkId,
+    ethNodeUrl,
+    ethMasterSk,
+    ethClientAbiPath,
+    ethClientAddress,
+    ethGasMultiplier
+  }) {
     // @ts-ignore
-    this.robustWeb3 = new RobustWeb3(RainbowConfig.getParam('eth-node-url'))
+    this.robustWeb3 = new RobustWeb3(ethNodeUrl)
     this.web3 = this.robustWeb3.web3
     this.ethMasterAccount = this.web3.eth.accounts.privateKeyToAccount(
-      ethMasterSk
-        ? normalizeEthKey(ethMasterSk)
-        : normalizeEthKey(RainbowConfig.getParam('eth-master-sk'))
+      normalizeEthKey(ethMasterSk)
     )
     this.web3.eth.accounts.wallet.add(this.ethMasterAccount)
     this.web3.eth.defaultAccount = this.ethMasterAccount.address
@@ -267,8 +35,8 @@ class Near2EthRelay {
 
     const keyStore = new nearAPI.keyStores.InMemoryKeyStore()
     this.near = await nearAPI.connect({
-      nodeUrl: RainbowConfig.getParam('near-node-url'),
-      networkId: RainbowConfig.getParam('near-network-id'),
+      nodeUrl: nearNodeUrl,
+      networkId: nearNetworkId,
       deps: {
         keyStore: keyStore
       }
@@ -278,9 +46,9 @@ class Near2EthRelay {
     this.clientContract = new this.web3.eth.Contract(
       // @ts-ignore
       JSON.parse(
-        fs.readFileSync(RainbowConfig.getParam('eth-client-abi-path'))
+        fs.readFileSync(ethClientAbiPath)
       ),
-      RainbowConfig.getParam('eth-client-address'),
+      ethClientAddress,
       {
         from: this.ethMasterAccount,
         handleRevert: true
@@ -331,9 +99,7 @@ class Near2EthRelay {
           currentValidators
         )
         // @ts-ignore
-        let gasPrice = new BN(await this.web3.eth.getGasPrice()).mul(
-          new BN(RainbowConfig.getParam('eth-gas-multiplier'))
-        )
+        let gasPrice = new BN(await this.web3.eth.getGasPrice()).mul(new BN(ethGasMultiplier))
         let err
         for (let i = 0; i < 10; i++) {
           try {
@@ -370,7 +136,7 @@ class Near2EthRelay {
               gas: 4000000,
               handleRevert: true,
               gasPrice: new BN(await this.web3.eth.getGasPrice()).mul(
-                new BN(RainbowConfig.getParam('eth-gas-multiplier'))
+                new BN(ethGasMultiplier)
               )
             })
           } catch (e) {
@@ -396,18 +162,22 @@ class Near2EthRelay {
     }
   }
 
-  async runInternal (submitInvalidBlock) {
+  async runInternal ({
+    submitInvalidBlock,
+    near2ethRelayMinDelay,
+    near2ethRelayMaxDelay,
+    near2ethRelayErrorDelay,
+    ethGasMultiplier
+  }) {
     const clientContract = this.clientContract
     const robustWeb3 = this.robustWeb3
     const near = this.near
     const ethMasterAccount = this.ethMasterAccount
     const web3 = this.web3
 
-    const minDelay = Number(RainbowConfig.getParam('near2eth-relay-min-delay'))
-    const maxDelay = Number(RainbowConfig.getParam('near2eth-relay-max-delay'))
-    const errorDelay = Number(
-      RainbowConfig.getParam('near2eth-relay-error-delay')
-    )
+    const minDelay = Number(near2ethRelayMinDelay)
+    const maxDelay = Number(near2ethRelayMaxDelay)
+    const errorDelay = Number(near2ethRelayErrorDelay)
 
     while (true) {
       try {
@@ -456,9 +226,7 @@ class Near2EthRelay {
                 gas: 1000000,
                 handleRevert: true,
                 value: new BN(lockEthAmount),
-                gasPrice: new BN(await web3.eth.getGasPrice()).mul(
-                  new BN(RainbowConfig.getParam('eth-gas-multiplier'))
-                )
+                gasPrice: new BN(await web3.eth.getGasPrice()).mul(new BN(ethGasMultiplier))
               })
               console.log('Transferred.')
             }
@@ -473,9 +241,7 @@ class Near2EthRelay {
               from: ethMasterAccount,
               gas: 4000000,
               handleRevert: true,
-              gasPrice: new BN(await web3.eth.getGasPrice()).mul(
-                new BN(RainbowConfig.getParam('eth-gas-multiplier'))
-              )
+              gasPrice: new BN(await web3.eth.getGasPrice()).mul(new BN(ethGasMultiplier))
             })
 
             if (submitInvalidBlock) {
@@ -511,23 +277,63 @@ class Near2EthRelay {
     }
   }
 
-  DANGERsubmitInvalidNearBlock () {
-    return this.runInternal(true)
+  DANGERsubmitInvalidNearBlock (options) {
+    return this.runInternal({
+      ...options,
+      submitInvalidBlock: true
+    })
   }
 
-  run () {
-    return this.runInternal(false)
+  run (options) {
+    return this.runInternal({
+      ...options,
+      submitInvalidBlock: false
+    })
   }
 }
 
-async function runNear2EthRelay (ethMasterSk) {
-  const relay = new Near2EthRelay()
-  await relay.initialize(ethMasterSk)
-  relay.run()
-}
+// TODO: remove it unless we use it somewhere
+//
+// async function runNear2EthRelay ({
+//   nearNodeUrl,
+//   nearNetworkId,
+//   ethNodeUrl,
+//   ethMasterSk,
+//   ethClientAbiPath,
+//   ethClientAddress,
+//   ethGasMultiplier,
+//   near2ethRelayMinDelay,
+//   near2ethRelayMaxDelay,
+//   near2ethRelayErrorDelay
+// }) {
+//   const relay = new Near2EthRelay()
+
+//   // TODO remove this hard-coded constant! This is for testing purposes only. Replace with config when possible.
+//   ethMasterSk = normalizeEthKey('0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201')
+
+//   await relay.initialize({
+//     ethNodeUrl,
+//     ethMasterSk,
+//     nearNodeUrl,
+//     nearNetworkId,
+//     ethClientAbiPath,
+//     ethClientAddress,
+//     ethGasMultiplier
+//   })
+//   relay.run({
+//     near2ethRelayMinDelay,
+//     near2ethRelayMaxDelay,
+//     near2ethRelayErrorDelay,
+//     ethGasMultiplier
+//   })
+
+//   return {
+//     ethMasterSk
+//   }
+// }
 
 exports.Near2EthRelay = Near2EthRelay
 exports.borshify = borshify
-exports.runNear2EthRelay = runNear2EthRelay
+// exports.runNear2EthRelay = runNear2EthRelay
 
-require('make-runnable')
+// require('make-runnable')

--- a/near2eth/near2eth-block-relay/index.js
+++ b/near2eth/near2eth-block-relay/index.js
@@ -292,48 +292,5 @@ class Near2EthRelay {
   }
 }
 
-// TODO: remove it unless we use it somewhere
-//
-// async function runNear2EthRelay ({
-//   nearNodeUrl,
-//   nearNetworkId,
-//   ethNodeUrl,
-//   ethMasterSk,
-//   ethClientAbiPath,
-//   ethClientAddress,
-//   ethGasMultiplier,
-//   near2ethRelayMinDelay,
-//   near2ethRelayMaxDelay,
-//   near2ethRelayErrorDelay
-// }) {
-//   const relay = new Near2EthRelay()
-
-//   // TODO remove this hard-coded constant! This is for testing purposes only. Replace with config when possible.
-//   ethMasterSk = normalizeEthKey('0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201')
-
-//   await relay.initialize({
-//     ethNodeUrl,
-//     ethMasterSk,
-//     nearNodeUrl,
-//     nearNetworkId,
-//     ethClientAbiPath,
-//     ethClientAddress,
-//     ethGasMultiplier
-//   })
-//   relay.run({
-//     near2ethRelayMinDelay,
-//     near2ethRelayMaxDelay,
-//     near2ethRelayErrorDelay,
-//     ethGasMultiplier
-//   })
-
-//   return {
-//     ethMasterSk
-//   }
-// }
-
 exports.Near2EthRelay = Near2EthRelay
 exports.borshify = borshify
-// exports.runNear2EthRelay = runNear2EthRelay
-
-// require('make-runnable')

--- a/near2eth/near2eth-block-relay/package.json
+++ b/near2eth/near2eth-block-relay/package.json
@@ -21,7 +21,6 @@
     "eth-object": "near/eth-object#54e03b8aac8208cf724e206d49ffb8bdd30451d7",
     "eth-util-lite": "near/eth-util-lite#master",
     "ethereumjs-util": "^6.2.0",
-    "make-runnable": "^1.3.8",
     "rainbow-bridge-utils": "1.0.0"
   },
   "devDependencies": {

--- a/near2eth/watchdog/index.js
+++ b/near2eth/watchdog/index.js
@@ -1,6 +1,5 @@
 const fs = require('fs')
 const {
-  RainbowConfig,
   sleep,
   Web3,
   RobustWeb3,
@@ -12,13 +11,16 @@ const Tx = require('ethereumjs-tx').Transaction
 const SLOW_TX_ERROR_MSG = 'transaction not executed within 5 minutes'
 
 class Watchdog {
-  async initialize () {
+  async initialize ({
+    ethNodeUrl,
+    ethMasterSk,
+    ethClientAbiPath,
+    ethClientAddress
+  }) {
     // @ts-ignore
-    this.robustWeb3 = new RobustWeb3(RainbowConfig.getParam('eth-node-url'))
+    this.robustWeb3 = new RobustWeb3(ethNodeUrl)
     this.web3 = this.robustWeb3.web3
-    const ethMasterAccount = this.web3.eth.accounts.privateKeyToAccount(
-      normalizeEthKey(RainbowConfig.getParam('eth-master-sk'))
-    )
+    const ethMasterAccount = this.web3.eth.accounts.privateKeyToAccount(normalizeEthKey(ethMasterSk))
     this.web3.eth.accounts.wallet.add(ethMasterAccount)
     this.web3.eth.defaultAccount = ethMasterAccount.address
     this.ethMasterAccount = ethMasterAccount.address
@@ -27,10 +29,8 @@ class Watchdog {
     console.log('Deploying Near2EthClient contract.')
     this.clientContract = new this.web3.eth.Contract(
       // @ts-ignore
-      JSON.parse(
-        fs.readFileSync(RainbowConfig.getParam('eth-client-abi-path'))
-      ),
-      RainbowConfig.getParam('eth-client-address'),
+      JSON.parse(fs.readFileSync(ethClientAbiPath)),
+      ethClientAddress,
       {
         from: this.ethMasterAccount,
         handleRevert: true
@@ -38,14 +38,11 @@ class Watchdog {
     )
   }
 
-  async run () {
-    let privateKey = RainbowConfig.getParam('eth-master-sk')
-    if (privateKey.startsWith('0x')) {
-      privateKey = privateKey.slice(2)
+  async run ({ ethMasterSk, ethClientAddress, watchdogDelay, watchdogErrorDelay }) {
+    if (ethMasterSk.startsWith('0x')) {
+      ethMasterSk = ethMasterSk.slice(2)
     }
-    privateKey = Buffer.from(privateKey, 'hex')
-    const delay = RainbowConfig.getParam('watchdog-delay')
-    const errorDelay = RainbowConfig.getParam('watchdog-error-delay')
+    ethMasterSk = Buffer.from(ethMasterSk, 'hex')
     while (true) {
       try {
         const bridgeState = await this.clientContract.methods
@@ -82,7 +79,7 @@ class Watchdog {
                     let tx = new Tx({
                       from: this.ethMasterAccount.address,
                       // this is required otherwise gas is infinite
-                      to: RainbowConfig.getParam('eth-client-address'),
+                      to: ethClientAddress,
                       gasLimit: Web3.utils.toHex(2000000),
                       gasPrice: Web3.utils.toHex(gasPrice),
                       nonce: Web3.utils.toHex(nonce),
@@ -90,7 +87,7 @@ class Watchdog {
                         .challenge(this.ethMasterAccount, i)
                         .encodeABI()
                     })
-                    tx.sign(privateKey)
+                    tx.sign(ethMasterSk)
                     tx = '0x' + tx.serialize().toString('hex')
 
                     await promiseWithTimeout(
@@ -120,11 +117,11 @@ class Watchdog {
             }
           }
         }
-        console.log(`Sleeping for ${delay} seconds.`)
-        await sleep(delay * 1000)
+        console.log(`Sleeping for ${watchdogDelay} seconds.`)
+        await sleep(watchdogDelay * 1000)
       } catch (e) {
         console.log('Error', e)
-        await sleep(errorDelay * 1000)
+        await sleep(watchdogErrorDelay * 1000)
       }
     }
   }

--- a/near2eth/watchdog/index.js
+++ b/near2eth/watchdog/index.js
@@ -38,7 +38,12 @@ class Watchdog {
     )
   }
 
-  async run ({ ethMasterSk, ethClientAddress, watchdogDelay, watchdogErrorDelay }) {
+  async run ({
+    ethMasterSk,
+    ethClientAddress,
+    watchdogDelay,
+    watchdogErrorDelay
+  }) {
     if (ethMasterSk.startsWith('0x')) {
       ethMasterSk = ethMasterSk.slice(2)
     }

--- a/testing/adapter/index.js
+++ b/testing/adapter/index.js
@@ -1,35 +1,20 @@
 const fs = require('fs')
 const {
-  RainbowConfig,
   RobustWeb3,
   remove0x,
   normalizeEthKey
 } = require('rainbow-bridge-utils')
 
 // TODO use config instead
-const BRIDGE_SRC_DIR = __dirname
-const path = require('path')
 const { exit } = require('process')
-const LIBS_TC_SRC_DIR = path.join(
-  BRIDGE_SRC_DIR,
-  '../../node_modules/rainbow-token-connector'
-)
-RainbowConfig.declareOption(
-  'eth-erc20-abi-path',
-  'Path to the .abi file defining Ethereum ERC20 contract.',
-  path.join(LIBS_TC_SRC_DIR, 'res/TToken.full.abi')
-)
 
-function getBalance (ethSecretKey, tokenAddressArg = null) {
-  const tokenAddress = tokenAddressArg
-    ? remove0x(tokenAddressArg)
-    : RainbowConfig.getParam('eth-erc20-address')
-  const robustWeb3 = new RobustWeb3(RainbowConfig.getParam('eth-node-url'))
+function getEthErc20Balance ({ ethSecretKey, ethNodeUrl, ethErc20Address, ethErc20AbiPath }) {
+  const robustWeb3 = new RobustWeb3(ethNodeUrl)
   const web3 = robustWeb3.web3
 
   const ethContract = new web3.eth.Contract(
-    JSON.parse(fs.readFileSync(RainbowConfig.getParam('eth-erc20-abi-path'))),
-    tokenAddress
+    JSON.parse(fs.readFileSync(ethErc20AbiPath)),
+    ethErc20Address
   )
   const ethAccount = web3.eth.accounts.privateKeyToAccount(
     normalizeEthKey(ethSecretKey)
@@ -43,8 +28,4 @@ function getBalance (ethSecretKey, tokenAddressArg = null) {
   })
 }
 
-exports.getBalance = getBalance
-
-require('make-runnable/custom')({
-  printOutputFrame: false
-})
+exports.getEthErc20Balance = getEthErc20Balance

--- a/testing/index.js
+++ b/testing/index.js
@@ -3,7 +3,11 @@ const {
   TransferEthERC20FromNear,
   DeployToken
 } = require('./transfer-eth-erc20')
+const {
+  getEthErc20Balance
+} = require('./adapter')
 
 exports.TransferETHERC20ToNear = TransferETHERC20ToNear
 exports.TransferEthERC20FromNear = TransferEthERC20FromNear
 exports.DeployToken = DeployToken
+exports.getEthErc20Balance = getEthErc20Balance

--- a/testing/transfer-eth-erc20/from-near.js
+++ b/testing/transfer-eth-erc20/from-near.js
@@ -59,7 +59,7 @@ class TransferEthERC20FromNear {
   static async withdraw ({
     nearTokenContract,
     nearSenderAccountId,
-    tokenAccount,
+    nearErc20Account,
     amount,
     ethReceiverAddress,
     nearSenderAccount
@@ -79,7 +79,7 @@ class TransferEthERC20FromNear {
         `Withdrawing ${amount} tokens on NEAR blockchain in favor of ${ethReceiverAddress}.`
       )
       const txWithdraw = await nearJsonContractFunctionCall(
-        tokenAccount,
+        nearErc20Account,
         nearSenderAccount,
         'withdraw',
         { amount: amount, recipient: ethReceiverAddress },

--- a/testing/transfer-eth-erc20/to-near.js
+++ b/testing/transfer-eth-erc20/to-near.js
@@ -186,14 +186,13 @@ class TransferETHERC20ToNear {
     }
     TransferETHERC20ToNear.recordTransferLog({
       finished: 'block-safe',
-      proofLocker: proofLocker,
-      newOwnerId: newOwnerId
+      proofLocker,
+      newOwnerId
     })
   }
 
   static async deposit ({
     proofLocker,
-    nearFactoryContract,
     nearFactoryContractBorsh,
     nearTokenContract,
     newOwnerId
@@ -317,14 +316,6 @@ class TransferETHERC20ToNear {
     )
     await verifyAccount(near, nearMasterAccountId)
 
-    const nearFactoryContract = new nearAPI.Contract(
-      nearMasterAccount,
-      nearTokenFactoryAccount,
-      {
-        changeMethods: ['deposit'],
-        viewMethods: []
-      }
-    )
     const nearTokenContract = new nearAPI.Contract(
       nearMasterAccount,
       nearErc20Account,
@@ -400,7 +391,6 @@ class TransferETHERC20ToNear {
     }
     if (transferLog.finished === 'block-safe') {
       await TransferETHERC20ToNear.deposit({
-        nearFactoryContract,
         nearFactoryContractBorsh,
         nearTokenContract,
         ...transferLog

--- a/testing/transfer-eth-erc20/to-near.js
+++ b/testing/transfer-eth-erc20/to-near.js
@@ -367,7 +367,8 @@ class TransferETHERC20ToNear {
         robustWeb3,
         ethERC20Contract,
         amount,
-        ethSenderAccount
+        ethSenderAccount,
+        ethLockerAddress
       })
       transferLog = TransferETHERC20ToNear.loadTransferLog()
     }

--- a/testing/transfer-eth-erc20/to-near.js
+++ b/testing/transfer-eth-erc20/to-near.js
@@ -15,7 +15,6 @@ const {
   receiptFromWeb3,
   logFromWeb3
 } = require('rainbow-bridge-eth2near-block-relay')
-const { tokenAddressParam, tokenAccountParam } = require('./deploy-token')
 const { NearMintableToken } = require('./near-mintable-token')
 
 let initialCmd
@@ -263,7 +262,6 @@ class TransferETHERC20ToNear {
 
   static async execute ({
     parent: { rawArgs },
-    tokenName,
     amount,
     ethSenderSk,
     nearReceiverAccount,
@@ -282,13 +280,7 @@ class TransferETHERC20ToNear {
   }) {
     initialCmd = rawArgs.join(' ')
     let transferLog = TransferETHERC20ToNear.loadTransferLog()
-    const tokenAddress = tokenName
-      ? RainbowConfig.getParam(tokenAddressParam(tokenName))
-      : ethErc20Address
-    const tokenAccount = tokenName
-      ? RainbowConfig.getParam(tokenAccountParam(tokenName))
-      : nearErc20Account
-    console.log(`Using ETH address ${tokenAddress}`)
+    console.log(`Using ETH address ${ethErc20Address}`)
 
     // @ts-ignore
     const robustWeb3 = new RobustWeb3(ethNodeUrl)
@@ -303,7 +295,7 @@ class TransferETHERC20ToNear {
     const ethERC20Contract = new web3.eth.Contract(
       // @ts-ignore
       JSON.parse(fs.readFileSync(ethErc20AbiPath)),
-      tokenAddress
+      ethErc20Address
     )
 
     // @ts-ignore
@@ -335,7 +327,7 @@ class TransferETHERC20ToNear {
     )
     const nearTokenContract = new nearAPI.Contract(
       nearMasterAccount,
-      tokenAccount,
+      nearErc20Account,
       {
         changeMethods: [],
         viewMethods: ['get_balance']
@@ -383,7 +375,7 @@ class TransferETHERC20ToNear {
       await TransferETHERC20ToNear.lock({
         robustWeb3,
         ethTokenLockerContract,
-        tokenAddress,
+        ethErc20Address,
         amount,
         nearReceiverAccount,
         ethSenderAccount

--- a/testing/transfer-eth-erc20/to-near.js
+++ b/testing/transfer-eth-erc20/to-near.js
@@ -59,11 +59,11 @@ class TransferETHERC20ToNear {
 
   static async lock ({
     robustWeb3,
-    ethTokenLockerContract,
-    tokenAddress,
     amount,
-    nearReceiverAccount,
-    ethSenderAccount
+    ethTokenLockerContract,
+    ethErc20Address,
+    ethSenderAccount,
+    nearReceiverAccount
   }) {
     try {
       console.log(
@@ -74,7 +74,7 @@ class TransferETHERC20ToNear {
       const transaction = await robustWeb3.callContract(
         ethTokenLockerContract,
         'lockToken',
-        [tokenAddress, Number(amount), nearReceiverAccount],
+        [ethErc20Address, Number(amount), nearReceiverAccount],
         {
           from: ethSenderAccount,
           gas: 5000000

--- a/utils/config/index.js
+++ b/utils/config/index.js
@@ -21,9 +21,12 @@ class RainbowConfig {
       const declaration = this.paramDeclarations[option]
       const paramCase = changeCase.paramCase(option)
       const snakeCase = changeCase.snakeCase(option)
-      let defaultValue = declaration.defaultValue
+      let defaultValue = this.maybeGetParam(paramCase)
       if (defaultValue === null) {
-        defaultValue = undefined
+        defaultValue = declaration.defaultValue
+        if (defaultValue === null) {
+          defaultValue = undefined
+        }
       }
       prev = prev.option(
         `--${paramCase} <${snakeCase}>`,
@@ -33,16 +36,7 @@ class RainbowConfig {
       )
     }
     prev.action((...args) => {
-      const [commanderArgs] = args.splice(-1, 1)
-      const positionalArgs = args
-      const commanderArgsWithRainbowConfig = { ...commanderArgs }
-      for (const option of options) {
-        const optionCamelCase = changeCase.camelCase(option)
-        if (!Object.prototype.hasOwnProperty.call(commanderArgsWithRainbowConfig, optionCamelCase)) {
-          commanderArgsWithRainbowConfig[optionCamelCase] = this.getParam(option)
-        }
-      }
-      const newOptions = handler(...positionalArgs, commanderArgsWithRainbowConfig)
+      const newOptions = handler(...args)
       if (newOptions) {
         for (const [optionCamelCase, optionValue] of Object.entries(newOptions)) {
           this.setParam(changeCase.paramCase(optionCamelCase), optionValue)

--- a/utils/config/index.js
+++ b/utils/config/index.js
@@ -18,7 +18,6 @@ class RainbowConfig {
   static addOptions (command, handler, options) {
     let prev = command
     for (const option of options) {
-      console.log('option', option)
       const declaration = this.paramDeclarations[option]
       const paramCase = changeCase.paramCase(option)
       const snakeCase = changeCase.snakeCase(option)
@@ -44,11 +43,13 @@ class RainbowConfig {
         }
       }
       const newOptions = handler(...positionalArgs, commanderArgsWithRainbowConfig)
-      for (const [optionCamelCase, optionValue] of Object.entries(newOptions)) {
-        this.setParam(changeCase.paramCase(optionCamelCase), optionValue)
-      }
-      if (newOptions && Object.keys(newOptions).length > 0) {
-        this.saveConfig()
+      if (newOptions) {
+        for (const [optionCamelCase, optionValue] of Object.entries(newOptions)) {
+          this.setParam(changeCase.paramCase(optionCamelCase), optionValue)
+        }
+        if (newOptions && Object.keys(newOptions).length > 0) {
+          this.saveConfig()
+        }
       }
     })
   }

--- a/utils/config/index.js
+++ b/utils/config/index.js
@@ -35,13 +35,13 @@ class RainbowConfig {
         defaultValue
       )
     }
-    prev.action((...args) => {
-      const newOptions = handler(...args)
-      if (newOptions) {
-        for (const [optionCamelCase, optionValue] of Object.entries(newOptions)) {
+    prev.action(async (...args) => {
+      const newConfigValues = await handler(...args)
+      if (newConfigValues) {
+        for (const [optionCamelCase, optionValue] of Object.entries(newConfigValues)) {
           this.setParam(changeCase.paramCase(optionCamelCase), optionValue)
         }
-        if (newOptions && Object.keys(newOptions).length > 0) {
+        if (newConfigValues && Object.keys(newConfigValues).length > 0) {
           this.saveConfig()
         }
       }

--- a/utils/config/index.js
+++ b/utils/config/index.js
@@ -110,21 +110,6 @@ class RainbowConfig {
     this.paramValues[name] = { value: value, paramType: 'config' }
   }
 
-  // Get all args, but without daemon as array of strings.
-  static getArgsNoDaemon () {
-    const result = []
-    for (const name in this.paramValues) {
-      const value = this.paramValues[name]
-      if (value.paramType === 'arg' && name !== 'daemon') {
-        result.push(`--${name}`)
-        result.push(`${value.value}`)
-      }
-    }
-    result.push('--daemon')
-    result.push('false')
-    return result
-  }
-
   // Iterates over the params and writes them into config if they were set through arguments
   // or default values.
   static saveConfig () {

--- a/utils/config/index.js
+++ b/utils/config/index.js
@@ -16,7 +16,6 @@ class RainbowConfig {
   // Adds a list of options to the given commander action.
   // options is a list of string representing parameter name.
   static addOptions (command, handler, options) {
-    let prev = command
     for (const option of options) {
       const declaration = this.paramDeclarations[option]
       const paramCase = changeCase.paramCase(option)
@@ -28,14 +27,14 @@ class RainbowConfig {
           defaultValue = undefined
         }
       }
-      prev = prev.option(
+      command = command.option(
         `--${paramCase} <${snakeCase}>`,
         declaration.description,
         (value, previous) => this._processArg(option, value, previous),
         defaultValue
       )
     }
-    prev.action(async (...args) => {
+    command.action(async (...args) => {
       const newConfigValues = await handler(...args)
       if (newConfigValues) {
         for (const [optionCamelCase, optionValue] of Object.entries(newConfigValues)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -474,7 +474,7 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -1016,15 +1016,6 @@ cli-tableau@^2.0.0:
   dependencies:
     chalk "3.0.0"
 
-cliui@^7.0.2:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.3.tgz#ef180f26c8d9bff3927ee52428bfec2090427981"
-  integrity sha512-Gj3QHTkVMPKqwP3f7B4KPkBZRMR9r4rfi5bXFpg1a+Svvj8l7q5CnkBkVQzfxT5DFSsGk2+PascOgL0JYkL2kw==
-  dependencies:
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
-    wrap-ansi "^7.0.0"
-
 clone-response@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
@@ -1530,11 +1521,6 @@ emoji-regex@^7.0.1:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
-emoji-regex@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
-  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -1658,11 +1644,6 @@ es6-symbol@^3.1.1, es6-symbol@~3.1.3:
   dependencies:
     d "^1.0.1"
     ext "^1.1.2"
-
-escalade@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
-  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -2354,11 +2335,6 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-get-caller-file@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
-  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
-
 get-intrinsic@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.0.1.tgz#94a9768fcbdd0595a1c9273aacf4c89d075631be"
@@ -2780,11 +2756,6 @@ is-fullwidth-code-point@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
-is-fullwidth-code-point@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
-  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
-
 is-function@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.2.tgz#4f097f30abf6efadac9833b17ca5dc03f8144e08"
@@ -3171,14 +3142,6 @@ make-dir@^3.0.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
-
-make-runnable@^1.3.8:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/make-runnable/-/make-runnable-1.3.8.tgz#ce547757d776c1f369028dbd937731db9514fe6a"
-  integrity sha512-8lXEwzB1eLl1pGFx5JZxFbWac6v6bHfRrCn/xDO4Qk9H6DN0QqIsJOquGxz7NkZxedhh7uki1txsbgTci1W/Vw==
-  dependencies:
-    bluebird "^3.5.0"
-    yargs "^16.0.3"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -4309,11 +4272,6 @@ request@^2.79.0, request@^2.88.2:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-require-directory@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
-
 require-in-the-middle@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-5.0.3.tgz#ef8bfd771760db573bc86d1341d8ae411a04c600"
@@ -4716,15 +4674,6 @@ string-width@^3.0.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
-  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.0"
 
 string.prototype.matchall@^4.0.2:
   version "4.0.2"
@@ -5714,15 +5663,6 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -5835,11 +5775,6 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-y18n@^5.0.2:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
-  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
-
 yaeti@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
@@ -5857,24 +5792,6 @@ yamljs@0.3.0:
   dependencies:
     argparse "^1.0.7"
     glob "^7.0.5"
-
-yargs-parser@^20.2.2:
-  version "20.2.3"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.3.tgz#92419ba867b858c868acf8bae9bf74af0dd0ce26"
-  integrity sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==
-
-yargs@^16.0.3:
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.1.0.tgz#fc333fe4791660eace5a894b39d42f851cd48f2a"
-  integrity sha512-upWFJOmDdHN0syLuESuvXDmrRcWd1QafJolHskzaw79uZa7/x53gxQKiR07W59GWY1tFhhU/Th9DrtSfpS782g==
-  dependencies:
-    cliui "^7.0.2"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.0"
-    y18n "^5.0.2"
-    yargs-parser "^20.2.2"
 
 yauzl@^2.4.2:
   version "2.10.0"


### PR DESCRIPTION
*Resolves #344*

TODO:

* [x] Avoid direct reading of the config on the spot (pass all the necessary configuration options throgh the arguments)
  * [x] Avoid reading constant config variables (update the interfaces)
  * [x] Avoid readng config variables constructed at runtime (e.g. `eth-{tokenName}-address`)
  * [x] Test that all the invocations are passing the necessary parameters
* [x] Avoid direct writes to the config (return value from `execute` should be treated as diff to the RainbowConfig)