### PR TITLE
fix(watchdog): Don't fail on skipped signature

### DIFF
--- a/near2eth/watchdog/index.js
+++ b/near2eth/watchdog/index.js
@@ -66,10 +66,11 @@ class Watchdog {
                 .checkBlockProducerSignatureInHead(i)
                 .call()
             } catch (e) {
-              if (!e.reason || !e.signature) {
+              if (e.message.endsWith('This signature was skipped')) {
+                continue
+              } else {
                 throw e
               }
-              continue
             }
             if (!result) {
               console.log(`Challenging signature ${i}.`)


### PR DESCRIPTION
When some of the blocks are not signed by all validators, bridge watchdog is unable to check the full block. Skip missing signatures.