### PR TITLE
fix: Don't use env::signer_account_id

### DIFF
--- a/contracts/near/admin-controlled/src/lib.rs
+++ b/contracts/near/admin-controlled/src/lib.rs
@@ -1,14 +1,13 @@
+pub mod macros;
+pub use macros::*;
+
 use near_sdk::env;
 
 pub type Mask = u128;
 
 pub trait AdminControlled {
     fn is_owner(&self) -> bool {
-        env::current_account_id() == env::signer_account_id()
-    }
-
-    fn assert_owner(&self) {
-        assert!(self.is_owner());
+        env::current_account_id() == env::predecessor_account_id()
     }
 
     /// Return the current mask representing all paused events.

--- a/contracts/near/admin-controlled/src/macros.rs
+++ b/contracts/near/admin-controlled/src/macros.rs
@@ -1,0 +1,21 @@
+#[macro_export]
+macro_rules! impl_admin_controlled {
+    ($contract: ident, $paused: ident) => {
+        use admin_controlled::{AdminControlled as AdminControlledInner, Mask as MaskInner};
+        use near_sdk as near_sdk_inner;
+
+        #[near_bindgen]
+        impl AdminControlledInner for $contract {
+            #[result_serializer(borsh)]
+            fn get_paused(&self) -> MaskInner {
+                self.$paused
+            }
+
+            #[result_serializer(borsh)]
+            fn set_paused(&mut self, #[serializer(borsh)] paused: MaskInner) {
+                near_sdk_inner::assert_self();
+                self.$paused = paused;
+            }
+        }
+    };
+}

--- a/contracts/near/eth-client/src/lib.rs
+++ b/contracts/near/eth-client/src/lib.rs
@@ -1,4 +1,4 @@
-use admin_controlled::{AdminControlled, Mask};
+use admin_controlled::Mask;
 use borsh::{BorshDeserialize, BorshSerialize};
 use eth_types::*;
 use near_sdk::collections::UnorderedMap;
@@ -108,20 +108,6 @@ pub struct EthClient {
 impl Default for EthClient {
     fn default() -> Self {
         env::panic(b"EthClient is not initialized");
-    }
-}
-
-#[near_bindgen]
-impl AdminControlled for EthClient {
-    #[result_serializer(borsh)]
-    fn get_paused(&self) -> Mask {
-        self.paused
-    }
-
-    #[result_serializer(borsh)]
-    fn set_paused(&mut self, #[serializer(borsh)] paused: Mask) {
-        self.assert_owner();
-        self.paused = paused;
     }
 }
 
@@ -441,3 +427,5 @@ impl EthClient {
         (H256(pair.0), H256(pair.1))
     }
 }
+
+admin_controlled::impl_admin_controlled!(EthClient, paused);

--- a/contracts/near/eth-prover/src/lib.rs
+++ b/contracts/near/eth-prover/src/lib.rs
@@ -1,4 +1,4 @@
-use admin_controlled::{AdminControlled, Mask};
+use admin_controlled::Mask;
 use borsh::{BorshDeserialize, BorshSerialize};
 use eth_types::*;
 use near_sdk::{env, ext_contract, near_bindgen, PromiseOrValue};
@@ -320,16 +320,4 @@ impl EthProver {
     }
 }
 
-#[near_bindgen]
-impl AdminControlled for EthProver {
-    #[result_serializer(borsh)]
-    fn get_paused(&self) -> Mask {
-        self.paused
-    }
-
-    #[result_serializer(borsh)]
-    fn set_paused(&mut self, #[serializer(borsh)] paused: Mask) {
-        self.assert_owner();
-        self.paused = paused;
-    }
-}
+admin_controlled::impl_admin_controlled!(EthProver, paused);


### PR DESCRIPTION
Instead use env::predecessor_account_id. Using signer_account_id
has the same problems of using tx.origin in Ethereum. See link
below for more details:

https://github.com/ethereum/solidity/issues/683